### PR TITLE
Bump 0.0.16; Revert "Preserve callbackWaitsForEmptyEventLoop; rm deepcopy"

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,8 +7,9 @@ var util = require("util")
 var url = require("url")
 var path = require("path")
 var os = require("os")
+var deepcopy = require('deepcopy')
 
-const VERSION = "0.0.15"
+const VERSION = "0.0.16"
 const DEFAULT_COLLECTOR_URL = "https://metrics-api.iopipe.com"
 
 function _make_generateLog(emitter, func, start_time, config, context) {
@@ -156,35 +157,28 @@ module.exports = function(configObject) {
       var start_time = process.hrtime()
       var generateLog = _make_generateLog(emitter, func, start_time, config, args[1])
       var new_context = (old_context) => {
-        var context = Object.assign({
-          set callbackWaitsForEmptyEventLoop(value) {
-            old_context.callbackWaitsForEmptyEventLoop = value
-          },
-          get callbackWaitsForEmptyEventLoop() {
-            return old_context.callbackWaitsForEmptyEventLoop
-          },
-          succeed: function(data) {
-            //console.log("WOLF:CalledContextSucceed.")
-            generateLog(null, () => {
-              old_context.succeed(data)
-            })
-          },
-          fail: function(err) {
-            //console.log("WOLF:CalledContextFail.")
-            generateLog(err, () => {
-              old_context.fail(err)
-            })
-          },
-          done: function(err, data) {
-            //console.log("WOLF:CalledContextDone.")
-            generateLog(err, () => {
-              old_context.done(err, data)
-            })
-          },
-          iopipe_log: function(level, data) {
-            emitter.queue.push([level, data])
-          }
-        }, old_context)
+        var context = deepcopy(old_context)
+        context.succeed = function(data) {
+          //console.log("WOLF:CalledContextSucceed.")
+          generateLog(null, () => {
+            old_context.succeed(data)
+          })
+        }
+        context.fail = function(err) {
+          //console.log("WOLF:CalledContextFail.")
+          generateLog(err, () => {
+            old_context.fail(err)
+          })
+        }
+        context.done = function(err, data) {
+          //console.log("WOLF:CalledContextDone.")
+          generateLog(err, () => {
+            old_context.done(err, data)
+          })
+        }
+        context.iopipe_log = function(level, data) {
+          emitter.queue.push([level, data])
+        }
 
         return context
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iopipe",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "IOpipe Lambda Analytics & Tracing Agent",
   "main": "index.js",
   "scripts": {
@@ -27,6 +27,7 @@
   "homepage": "https://github.com/iopipe/iopipe#readme",
   "dependencies": {
     "crypto": "0.0.3",
+    "deepcopy": "^0.6.3",
     "request": "^2.72.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps 0.0.16; This reverts commit ddb3fb62a6b2941b60f65fc42888b9214e9a991a.

Conflicts:
    index.js
