### PR TITLE
Record coldstarts & time

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,6 +13,11 @@ var Callback = require('./src/callback.js')
 
 const VERSION = pkg.version
 const DEFAULT_COLLECTOR_URL = 'https://metrics-api.iopipe.com'
+const MODULE_LOAD_TIME = Date.now()
+
+// Default on module load; changed to false on first handler invocation.
+var COLDSTART = true
+
 
 function _make_generateLog(metrics, func, start_time, config, context) {
   var pre_stat_promise = system.readstat('self')
@@ -32,7 +37,8 @@ function _make_generateLog(metrics, func, start_time, config, context) {
         var runtime_env = {
           agent: {
             runtime: 'nodejs',
-            version: VERSION
+            version: VERSION,
+            load_time: MODULE_LOAD_TIME
           },
           host: {
             vm_id: boot_id
@@ -114,6 +120,7 @@ function _make_generateLog(metrics, func, start_time, config, context) {
             logGroupName: context.logGroupName,
             logStreamName: context.logStreamName
           },
+          coldstart: COLDSTART,
           errors: retainErr,
           custom_metrics: metrics,
           time_sec_nanosec: time_sec_nanosec,
@@ -121,6 +128,10 @@ function _make_generateLog(metrics, func, start_time, config, context) {
           time_nanosec: time_sec_nanosec[1],
           duration: Math.ceil(time_sec_nanosec[0] * 1000000000.0 + time_sec_nanosec[1]),
           client_id: config.clientId
+        }
+
+        if (COLDSTART === true) {
+          COLDSTART = false
         }
 
         if (context.getRemainingTimeInMillis) {


### PR DESCRIPTION
Detect coldstarts and log the time the process
has started. The process time is taken from stat,
and must be calculated using the clock HZ and uptime.

Signed-off-by: Eric Windisch <eric@iopipe.com>