### PR TITLE
Submit self not 1 for pid

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ function _make_generateLog(emitter, func, start_time, config, context) {
             arch: os.arch(),
             linux: {
               pid: {
-                1: {
+                self: {
                   stat_start: pre_proc_self_stat,
                   stat: proc_self_stat,
                   status: proc_self_status


### PR DESCRIPTION
We aren't even checking that it's pid 1, which
isn't necessarily the best assumption... and for
charting it's better we have something deterministic
like 'self' (which is what we're reading from /proc
anyway...)

Signed-off-by: Eric Windisch <eric@iopipe.com>