### PR TITLE
Add regional collector urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,16 +3,14 @@
 var pkg = require('./package.json')
 var Promise = require('bluebird')
 var request = require('request')
-var url = require('url')
-var path = require('path')
 var os = require('os')
 
 var system = (process.platform === 'linux') ? require('./src/system.js') : require('./src/mockSystem.js')
+var getCollectorUrl = require('./src/collector.js')
 var Context = require('./src/context.js')
 var Callback = require('./src/callback.js')
 
 const VERSION = pkg.version
-const DEFAULT_COLLECTOR_URL = 'https://metrics-api.iopipe.com'
 
 function _make_generateLog(metrics, func, start_time, config, context) {
   var pre_stat_promise = system.readstat('self')
@@ -137,7 +135,7 @@ function _make_generateLog(metrics, func, start_time, config, context) {
         }
         request(
           {
-            url: config.url,
+            url: getCollectorUrl(config.url, context),
             method: 'POST',
             json: true,
             body: response_body
@@ -156,13 +154,8 @@ function _make_generateLog(metrics, func, start_time, config, context) {
 }
 
 function setConfig(configObject) {
-  var baseurl = (configObject && configObject.url) ? configObject.url : DEFAULT_COLLECTOR_URL
-  var eventURL = url.parse(baseurl)
-  eventURL.pathname = path.join(eventURL.pathname, 'v0/event')
-  eventURL.path = eventURL.search ? eventURL.pathname + eventURL.search : eventURL.pathname
-
   return {
-    url: eventURL,
+    url: (configObject && configObject.url) ? configObject.url : '',
     clientId: configObject && configObject.clientId || process.env.IOPIPE_CLIENTID || '',
     debug: configObject && configObject.debug || process.env.IOPIPE_DEBUG || false
   }

--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function _make_generateLog(metrics, func, start_time, config, context) {
         }
         request(
           {
-            url: getCollectorUrl(config.url, context),
+            url: getCollectorUrl(config.url),
             method: 'POST',
             json: true,
             body: response_body

--- a/spec/agent_spec.js
+++ b/spec/agent_spec.js
@@ -93,7 +93,7 @@ describe('smoke test', () => {
   })
 
   describe('functions using callbacks', () => {
-    it('will run when installed on a sucessfull function', (done) => {
+    it('will run when installed on a sucessful function', (done) => {
       const ctx = context()
       function cb(err, success) {
         if(err)
@@ -115,6 +115,93 @@ describe('smoke test', () => {
           expect(err).toBe(null)
           done()
         })
+    })
+  })
+
+  describe('sends to specified regions', function() {
+    it('sends to ap-southeast-2', function(done) {
+      var iopipe = IOpipe({ clientId: 'testSuite' })
+      var ctx = context({ region: 'ap-southeast-2'})
+      var wrappedFunction = iopipe.decorate(function(event, context) {
+        context.succeed(true)
+      })
+
+      wrappedFunction({}, ctx)
+
+      ctx.Promise
+        .then(resp => { expect(resp).toBeTruthy(); done() })
+        .catch(err => { expect(err).toBe(null); done() })
+    })
+
+    it('sends to eu-west-1', function(done) {
+      var iopipe = IOpipe({ clientId: 'testSuite' })
+      var ctx = context({ region: 'eu-west-1'})
+      var wrappedFunction = iopipe.decorate(function(event, context) {
+        context.succeed(true)
+      })
+
+      wrappedFunction({}, ctx)
+
+      ctx.Promise
+        .then(resp => { expect(resp).toBeTruthy(); done() })
+        .catch(err => { expect(err).toBe(null); done() })
+    })
+
+    it('sends to us-east-1/our default URL', function(done) {
+      var iopipe = IOpipe({ clientId: 'testSuite' })
+      var ctx = context({ region: 'us-east-1'})
+      var wrappedFunction = iopipe.decorate(function(event, context) {
+        context.succeed(true)
+      })
+
+      wrappedFunction({}, ctx)
+
+      ctx.Promise
+        .then(resp => { expect(resp).toBeTruthy(); done() })
+        .catch(err => { expect(err).toBe(null); done() })
+    })
+
+    it('sends to us-east-2', function(done) {
+      var iopipe = IOpipe({ clientId: 'testSuite' })
+      var ctx = context({ region: 'us-east-2'})
+      var wrappedFunction = iopipe.decorate(function(event, context) {
+        context.succeed(true)
+      })
+
+      wrappedFunction({}, ctx)
+
+      ctx.Promise
+        .then(resp => { expect(resp).toBeTruthy(); done() })
+        .catch(err => { expect(err).toBe(null); done() })
+    })
+
+
+    it('sends to us-west-1', function(done) {
+      var iopipe = IOpipe({ clientId: 'testSuite' })
+      var ctx = context({ region: 'us-west-1' })
+      var wrappedFunction = iopipe.decorate(function(event, context) {
+        context.succeed(true)
+      })
+
+      wrappedFunction({}, ctx)
+
+      ctx.Promise
+        .then(resp => { expect(resp).toBeTruthy(); done() })
+        .catch(err => { expect(err).toBe(null); done() })
+    })
+
+    it('sends to us-west-2', function(done) {
+      var iopipe = IOpipe({ clientId: 'testSuite' })
+      var ctx = context({ region: 'us-west-2' })
+      var wrappedFunction = iopipe.decorate(function(event, context) {
+        context.succeed(true)
+      })
+
+      wrappedFunction({}, ctx)
+
+      ctx.Promise
+        .then(resp => { expect(resp).toBeTruthy(); done() })
+        .catch(err => { expect(err).toBe(null); done() })
     })
   })
 })

--- a/spec/agent_spec.js
+++ b/spec/agent_spec.js
@@ -93,7 +93,7 @@ describe('smoke test', () => {
   })
 
   describe('functions using callbacks', () => {
-    it('will run when installed on a sucessful function', (done) => {
+    it('will run when installed on a successful function', (done) => {
       const ctx = context()
       function cb(err, success) {
         if(err)

--- a/spec/agent_spec.js
+++ b/spec/agent_spec.js
@@ -1,5 +1,7 @@
 const IOpipe = require('..')
 const context = require('aws-lambda-mock-context')
+// default region for testing
+process.env.AWS_REGION = 'us-east-1'
 
 describe('metrics agent', () => {
   it('should return a function', () => {
@@ -121,6 +123,7 @@ describe('smoke test', () => {
   describe('sends to specified regions', function() {
     it('sends to ap-southeast-2', function(done) {
       var iopipe = IOpipe({ clientId: 'testSuite' })
+      process.env.AWS_REGION = 'ap-southeast-2'
       var ctx = context({ region: 'ap-southeast-2'})
       var wrappedFunction = iopipe.decorate(function(event, context) {
         context.succeed(true)
@@ -135,6 +138,7 @@ describe('smoke test', () => {
 
     it('sends to eu-west-1', function(done) {
       var iopipe = IOpipe({ clientId: 'testSuite' })
+      process.env.AWS_REGION = 'eu-west-1'
       var ctx = context({ region: 'eu-west-1'})
       var wrappedFunction = iopipe.decorate(function(event, context) {
         context.succeed(true)
@@ -149,6 +153,7 @@ describe('smoke test', () => {
 
     it('sends to us-east-1/our default URL', function(done) {
       var iopipe = IOpipe({ clientId: 'testSuite' })
+      process.env.AWS_REGION = 'us-east-1'
       var ctx = context({ region: 'us-east-1'})
       var wrappedFunction = iopipe.decorate(function(event, context) {
         context.succeed(true)
@@ -163,6 +168,7 @@ describe('smoke test', () => {
 
     it('sends to us-east-2', function(done) {
       var iopipe = IOpipe({ clientId: 'testSuite' })
+      process.env.AWS_REGION = 'us-east-2'
       var ctx = context({ region: 'us-east-2'})
       var wrappedFunction = iopipe.decorate(function(event, context) {
         context.succeed(true)
@@ -178,6 +184,7 @@ describe('smoke test', () => {
 
     it('sends to us-west-1', function(done) {
       var iopipe = IOpipe({ clientId: 'testSuite' })
+      process.env.AWS_REGION = 'us-west-1'
       var ctx = context({ region: 'us-west-1' })
       var wrappedFunction = iopipe.decorate(function(event, context) {
         context.succeed(true)
@@ -192,6 +199,7 @@ describe('smoke test', () => {
 
     it('sends to us-west-2', function(done) {
       var iopipe = IOpipe({ clientId: 'testSuite' })
+      process.env.AWS_REGION = 'us-west-2'
       var ctx = context({ region: 'us-west-2' })
       var wrappedFunction = iopipe.decorate(function(event, context) {
         context.succeed(true)

--- a/spec/collector_spec.js
+++ b/spec/collector_spec.js
@@ -13,33 +13,37 @@ describe('configuring collector url', function() {
     expect(collector('http://myurl?foo').path).toBe('/v0/event?foo')
   })
 
-  it('switches based on the region in the ARN', function() {
-    var apSoutheast2Context = { invokedFunctionArn: 'arn:aws:lambda:ap-southeast-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
-    var euWest1Context = { invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
-    var east2Context = { invokedFunctionArn: 'arn:aws:lambda:us-east-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
-    var west1Context = { invokedFunctionArn: 'arn:aws:lambda:us-west-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
-    var west2Context = { invokedFunctionArn: 'arn:aws:lambda:us-west-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
+  it('switches based on the region set in env vars', function() {
+    process.env.AWS_REGION = 'ap-southeast-2'
+    var apSoutheast2Collector = collector('', {})
+    process.env.AWS_REGION = 'eu-west-1'
+    var euWest1Collector = collector('', {})
+    process.env.AWS_REGION = 'us-east-2'
+    var east2Collector = collector('', {})
+    process.env.AWS_REGION = 'us-west-1'
+    var west1Collector = collector('', {})
+    process.env.AWS_REGION = 'us-west-2'
+    var west2Collector = collector('', {})
 
-    expect(collector('', apSoutheast2Context).href).toBe('https://metrics-api.ap-southeast-2.iopipe.com/')
-    expect(collector('', euWest1Context).href).toBe('https://metrics-api.eu-west-1.iopipe.com/')
-    expect(collector('', east2Context).href).toBe('https://metrics-api.us-east-2.iopipe.com/')
-    expect(collector('', west1Context).href).toBe('https://metrics-api.us-west-1.iopipe.com/')
-    expect(collector('', west2Context).href).toBe('https://metrics-api.us-west-2.iopipe.com/')
+    expect(apSoutheast2Collector.href).toBe('https://metrics-api.ap-southeast-2.iopipe.com/')
+    expect(euWest1Collector.href).toBe('https://metrics-api.eu-west-1.iopipe.com/')
+    expect(east2Collector.href).toBe('https://metrics-api.us-east-2.iopipe.com/')
+    expect(west1Collector.href).toBe('https://metrics-api.us-west-1.iopipe.com/')
+    expect(west2Collector.href).toBe('https://metrics-api.us-west-2.iopipe.com/')
   })
 
   it('defaults if an uncovered region or malformed', function() {
-    var context = {
-      invokedFunctionArn: 'arn:aws:lambda:ap-east-1:123456789012:function:aws-lambda-mock-context:$LATEST'
-    }
+    process.env.AWS_REGION = 'eu-west-2'
+    var euWest2Collector = collector('', {})
 
-    var contextBadArn = {
-      invokedFunctionArn: 'this-isnt-even-an-arn'
-    }
+    process.env.AWS_REGION = 'NotARegion'
+    var notRegionCollector = collector('', {})
 
-    var contextNoArn = {}
+    process.env.AWS_REGION = ''
+    var emptyRegionCollector = collector('', {})
 
-    expect(collector('', context).href).toBe('https://metrics-api.iopipe.com/')
-    expect(collector('', contextBadArn).href).toBe('https://metrics-api.iopipe.com/')
-    expect(collector('', contextNoArn).href).toBe('https://metrics-api.iopipe.com/')
+    expect(euWest2Collector.href).toBe('https://metrics-api.iopipe.com/')
+    expect(notRegionCollector.href).toBe('https://metrics-api.iopipe.com/')
+    expect(emptyRegionCollector.href).toBe('https://metrics-api.iopipe.com/')
   })
 })

--- a/spec/collector_spec.js
+++ b/spec/collector_spec.js
@@ -16,14 +16,12 @@ describe('configuring collector url', function() {
   it('switches based on the region in the ARN', function() {
     var apSoutheast2Context = { invokedFunctionArn: 'arn:aws:lambda:ap-southeast-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
     var euWest1Context = { invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
-    var east1Context = { invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
     var east2Context = { invokedFunctionArn: 'arn:aws:lambda:us-east-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
     var west1Context = { invokedFunctionArn: 'arn:aws:lambda:us-west-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
     var west2Context = { invokedFunctionArn: 'arn:aws:lambda:us-west-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
 
     expect(collector('', apSoutheast2Context).href).toBe('https://metrics-api.ap-southeast-2.iopipe.com/')
     expect(collector('', euWest1Context).href).toBe('https://metrics-api.eu-west-1.iopipe.com/')
-    expect(collector('', east1Context).href).toBe('https://metrics-api.us-east-1.iopipe.com/')
     expect(collector('', east2Context).href).toBe('https://metrics-api.us-east-2.iopipe.com/')
     expect(collector('', west1Context).href).toBe('https://metrics-api.us-west-1.iopipe.com/')
     expect(collector('', west2Context).href).toBe('https://metrics-api.us-west-2.iopipe.com/')

--- a/spec/collector_spec.js
+++ b/spec/collector_spec.js
@@ -1,6 +1,11 @@
 var collector = require('../src/collector.js')
 
 describe('configuring collector url', function() {
+  beforeEach(function() {
+    // clear region for testing
+    process.env.AWS_REGION = ''
+  })
+
   it('returns a base url if nothing else', function() {
     expect(collector().href).toBe('https://metrics-api.iopipe.com/')
   })

--- a/spec/collector_spec.js
+++ b/spec/collector_spec.js
@@ -1,0 +1,47 @@
+var collector = require('../src/collector.js')
+
+describe('configuring collector url', function() {
+  it('returns a base url if nothing else', function() {
+    expect(collector().href).toBe('https://metrics-api.iopipe.com/')
+  })
+
+  it('returns a configured url if provided in config object', function() {
+    expect(collector('http://myurl').href).toBe('http://myurl/')
+  })
+
+  it('adds query strings to the path', function() {
+    expect(collector('http://myurl?foo').path).toBe('/v0/event?foo')
+  })
+
+  it('switches based on the region in the ARN', function() {
+    var apSoutheast2Context = { invokedFunctionArn: 'arn:aws:lambda:ap-southeast-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
+    var euWest1Context = { invokedFunctionArn: 'arn:aws:lambda:eu-west-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
+    var east1Context = { invokedFunctionArn: 'arn:aws:lambda:us-east-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
+    var east2Context = { invokedFunctionArn: 'arn:aws:lambda:us-east-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
+    var west1Context = { invokedFunctionArn: 'arn:aws:lambda:us-west-1:123456789012:function:aws-lambda-mock-context:$LATEST' }
+    var west2Context = { invokedFunctionArn: 'arn:aws:lambda:us-west-2:123456789012:function:aws-lambda-mock-context:$LATEST' }
+
+    expect(collector('', apSoutheast2Context).href).toBe('https://metrics-api.ap-southeast-2.iopipe.com/')
+    expect(collector('', euWest1Context).href).toBe('https://metrics-api.eu-west-1.iopipe.com/')
+    expect(collector('', east1Context).href).toBe('https://metrics-api.us-east-1.iopipe.com/')
+    expect(collector('', east2Context).href).toBe('https://metrics-api.us-east-2.iopipe.com/')
+    expect(collector('', west1Context).href).toBe('https://metrics-api.us-west-1.iopipe.com/')
+    expect(collector('', west2Context).href).toBe('https://metrics-api.us-west-2.iopipe.com/')
+  })
+
+  it('defaults if an uncovered region or malformed', function() {
+    var context = {
+      invokedFunctionArn: 'arn:aws:lambda:ap-east-1:123456789012:function:aws-lambda-mock-context:$LATEST'
+    }
+
+    var contextBadArn = {
+      invokedFunctionArn: 'this-isnt-even-an-arn'
+    }
+
+    var contextNoArn = {}
+
+    expect(collector('', context).href).toBe('https://metrics-api.iopipe.com/')
+    expect(collector('', contextBadArn).href).toBe('https://metrics-api.iopipe.com/')
+    expect(collector('', contextNoArn).href).toBe('https://metrics-api.iopipe.com/')
+  })
+})

--- a/src/collector.js
+++ b/src/collector.js
@@ -9,7 +9,7 @@ function addPathToUrl(baseUrl) {
   return eventURL
 }
 
-function getCollectorUrl(configUrl, context) {
+function getCollectorUrl(configUrl) {
   if (configUrl) {
     return addPathToUrl(configUrl)
   }

--- a/src/collector.js
+++ b/src/collector.js
@@ -1,0 +1,61 @@
+var url = require('url')
+var path = require('path')
+
+// Function regex according to Amazon:
+// https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html
+const arnExpression = /(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?/
+
+function arnToRegion(arn){
+  if (!arn) return ''
+
+  var splitArn = arn.match(arnExpression)
+  // guard to make sure we have a match in the region section
+  if (splitArn[2]) {
+    return splitArn[2].replace(':', '')
+  }
+  return ''
+}
+
+function addPathToUrl(baseUrl) {
+  var eventURL = url.parse(baseUrl)
+  eventURL.pathname = path.join(eventURL.pathname, 'v0/event')
+  eventURL.path = eventURL.search ? eventURL.pathname + eventURL.search : eventURL.pathname
+
+  return eventURL
+}
+
+function getCollectorUrl(configUrl, context) {
+  if (configUrl) {
+    return addPathToUrl(configUrl)
+  }
+
+  var baseUrl = 'https://metrics-api.iopipe.com'
+  var region = context ? arnToRegion(context.invokedFunctionArn) : ''
+
+  switch (region) {
+  case 'ap-southeast-2':
+    baseUrl = 'https://metrics-api.ap-southeast-2.iopipe.com'
+    break
+  case 'eu-west-1':
+    baseUrl = 'https://metrics-api.eu-west-1.iopipe.com'
+    break
+  case 'us-east-1':
+    baseUrl = 'https://metrics-api.us-east-1.iopipe.com'
+    break
+  case 'us-east-2':
+    baseUrl = 'https://metrics-api.us-east-2.iopipe.com'
+    break
+  case 'us-west-1':
+    baseUrl = 'https://metrics-api.us-west-1.iopipe.com'
+    break
+  case 'us-west-2':
+    baseUrl = 'https://metrics-api.us-west-2.iopipe.com'
+    break
+  default:
+    baseUrl = 'https://metrics-api.iopipe.com'
+  }
+
+  return addPathToUrl(baseUrl)
+}
+
+module.exports = getCollectorUrl

--- a/src/collector.js
+++ b/src/collector.js
@@ -1,21 +1,6 @@
 var url = require('url')
 var path = require('path')
 
-// Function regex according to Amazon:
-// https://docs.aws.amazon.com/lambda/latest/dg/API_UpdateFunctionConfiguration.html
-const arnExpression = /(arn:aws:lambda:)?([a-z]{2}-[a-z]+-\d{1}:)?(\d{12}:)?(function:)?([a-zA-Z0-9-_]+)(:(\$LATEST|[a-zA-Z0-9-_]+))?/
-
-function arnToRegion(arn){
-  if (!arn) return ''
-
-  var splitArn = arn.match(arnExpression)
-  // guard to make sure we have a match in the region section
-  if (splitArn[2]) {
-    return splitArn[2].replace(':', '')
-  }
-  return ''
-}
-
 function addPathToUrl(baseUrl) {
   var eventURL = url.parse(baseUrl)
   eventURL.pathname = path.join(eventURL.pathname, 'v0/event')
@@ -30,7 +15,7 @@ function getCollectorUrl(configUrl, context) {
   }
 
   var baseUrl = 'https://metrics-api.iopipe.com'
-  var region = context ? arnToRegion(context.invokedFunctionArn) : ''
+  var region = process.env.AWS_REGION || ''
 
   switch (region) {
   case 'ap-southeast-2':

--- a/src/collector.js
+++ b/src/collector.js
@@ -39,9 +39,6 @@ function getCollectorUrl(configUrl, context) {
   case 'eu-west-1':
     baseUrl = 'https://metrics-api.eu-west-1.iopipe.com'
     break
-  case 'us-east-1':
-    baseUrl = 'https://metrics-api.us-east-1.iopipe.com'
-    break
   case 'us-east-2':
     baseUrl = 'https://metrics-api.us-east-2.iopipe.com'
     break


### PR DESCRIPTION
Switch collector url by region, making requests to IOpipe faster for our users.