### PR TITLE
Support IOPIPE_TOKEN env var.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ exports.handle = iopipe(
 # Environment-based config
 
 This library will look for an environment variable,
-`IOPIPE_CLIENTID` and will use this if one is not
+`IOPIPE_TOKEN` and will use this if one is not
 explicitly passed to the configuration object.
 
 This is an easy way to separate configuration from

--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ function _make_generateLog(metrics, func, start_time, config, context) {
 function setConfig(configObject) {
   return {
     url: (configObject && configObject.url) ? configObject.url : '',
-    clientId: configObject && configObject.clientId || process.env.IOPIPE_CLIENTID || '',
+    clientId: configObject && configObject.clientId || process.env.IOPIPE_TOKEN || process.env.IOPIPE_CLIENTID || '',
     debug: configObject && configObject.debug || process.env.IOPIPE_DEBUG || false,
     network_timeout: 5000,
   }


### PR DESCRIPTION
Still supports IOPIPE_CLIENTID but removes it from
documentation and takes IOPIPE_TOKEN preferentially.