### PR TITLE
Allow usage of token key in config

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function _make_generateLog(metrics, func, start_time, config, context) {
 function setConfig(configObject) {
   return {
     url: (configObject && configObject.url) ? configObject.url : '',
-    clientId: configObject && configObject.clientId || process.env.IOPIPE_TOKEN || process.env.IOPIPE_CLIENTID || '',
+    clientId: configObject && (configObject.token || configObject.clientId) || process.env.IOPIPE_TOKEN || process.env.IOPIPE_CLIENTID || '',
     debug: configObject && configObject.debug || process.env.IOPIPE_DEBUG || false,
     networkTimeout: configObject && configObject.networkTimeout || 5000,
     timeoutWindow: configObject && configObject.timeoutWindow || 50


### PR DESCRIPTION
Use `token` if specified in object configuration, `clientId` then environment variables otherwise.