### PR TITLE
Async DNS query

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@
 const pkg = require('./package.json')
 const os = require('os')
 const https = require('https')
-const uuid = require('uuid/v4')
 const dns = require('dns')
 
 const system = (process.platform === 'linux') ? require('./src/system.js') : require('./src/mockSystem.js')

--- a/index.js
+++ b/index.js
@@ -192,6 +192,9 @@ function _make_generateLog(metrics, func, start_time, config, dnsPromise, contex
             }
             callback()
           })
+
+          req.write(JSON.stringify(response_body))
+          req.end()
         }).catch((err) => {
           // Log errors, don't block on failed requests
           if (config.debug) {
@@ -200,9 +203,6 @@ function _make_generateLog(metrics, func, start_time, config, dnsPromise, contex
           }
           callback()
         })
-
-        req.write(JSON.stringify(response_body))
-        req.end()
       }
     ).catch((err) => {
       if (err && config.debug) {
@@ -230,7 +230,7 @@ module.exports = function(options) {
 
       /* Only resolve DNS on coldstarts */
       var dnsPromise = new Promise((resolve, reject) => {
-        dns.lookup(config.host, (err, address, family) => {
+        dns.lookup(config.host, (err, address) => {
           if (err) {
             reject(err)
           }

--- a/index.js
+++ b/index.js
@@ -239,7 +239,7 @@ module.exports = function(options) {
       })
 
       var start_time = process.hrtime()
-      var generateLog = _make_generateLog(fn.metricsQueue, func, start_time, config, collectorUrlPromise, args[1])
+      var generateLog = _make_generateLog(fn.metricsQueue, func, start_time, config, dnsPromise, args[1])
 
       var end_time = 599900  /* Maximum execution: 100ms short of 5 minutes */
       if (config.timeoutWindow > 0 && args[1] && args[1].getRemainingTimeInMillis) {

--- a/index.js
+++ b/index.js
@@ -217,19 +217,19 @@ module.exports = function(options) {
       return func
     }
 
-    /* Only resolve DNS on coldstarts */
-    var dnsPromise = new Promise((resolve, reject) => {
-      dns.lookup(config.host, (err, address, family) => {
-        if (err) {
-          reject(err)
-        }
-        resolve(address)
-      })
-    })
-
     return function() {
       fn.metricsQueue = []
       let args = [].slice.call(arguments)
+
+      /* Only resolve DNS on coldstarts */
+      var dnsPromise = new Promise((resolve, reject) => {
+        dns.lookup(config.host, (err, address, family) => {
+          if (err) {
+            reject(err)
+          }
+          resolve(address)
+        })
+      })
 
       var start_time = process.hrtime()
       var generateLog = _make_generateLog(fn.metricsQueue, func, start_time, config, collectorUrlPromise, args[1])

--- a/index.js
+++ b/index.js
@@ -187,11 +187,18 @@ function _make_generateLog(metrics, func, start_time, config, dnsPromise, contex
           }).on('error', (err) => {
             // Log errors, don't block on failed requests
             if (config.debug) {
-              log('Write to IOpipe failed')
+              log('Write to IOpipe failed.')
               log(err)
             }
             callback()
           })
+        }).catch((err) => {
+          // Log errors, don't block on failed requests
+          if (config.debug) {
+            log('Write to IOpipe failed. DNS resolution error.')
+            log(err)
+          }
+          callback()
         })
 
         req.write(JSON.stringify(response_body))

--- a/src/config.js
+++ b/src/config.js
@@ -4,7 +4,7 @@ const getHostname = collector.getHostname,
 
 module.exports = function setConfig(configObject) {
   return {
-    url: (configObject && configObject.url) ? getHostname(configObject.url) : getHostname(),
+    host: (configObject && configObject.url) ? getHostname(configObject.url) : getHostname(),
     path: (configObject && configObject.url) ? getCollectorPath(configObject.url) : getCollectorPath(),
     clientId: configObject && (configObject.token || configObject.clientId) || process.env.IOPIPE_TOKEN || process.env.IOPIPE_CLIENTID || '',
     debug: configObject && configObject.debug || process.env.IOPIPE_DEBUG || false,


### PR DESCRIPTION
Perform the DNS query early
saves 5-10ms on coldstarts. Will also save time on invocations where the DNS TTL (i.e. cache) has expired.