### PR TITLE
Eliminate uuid dep

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@
 const pkg = require('./package.json')
 const os = require('os')
 const https = require('https')
-const uuid = require('uuid/v4')
 
 const system = (process.platform === 'linux') ? require('./src/system.js') : require('./src/mockSystem.js')
 const setConfig = require('./src/config.js')
 const Context = require('./src/context.js')
 const Callback = require('./src/callback.js')
+const uuid = require('./src/uuidv4')
 const log = console.log
 
 const VERSION = pkg.version

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
     "url": "https://github.com/iopipe/iopipe/issues"
   },
   "homepage": "https://github.com/iopipe/iopipe#readme",
-  "dependencies": {
-    "uuid": "^3.0.1"
-  },
   "devDependencies": {
     "aws-lambda-mock-context": "^3.0.0",
     "coveralls": "^2.11.12",

--- a/src/mockSystem.js
+++ b/src/mockSystem.js
@@ -1,4 +1,4 @@
-var uuid = require('uuid/v4')
+var uuid = require('./uuidv4')
 
 function readstat() {
   return Promise.resolve({

--- a/src/uuidv4.js
+++ b/src/uuidv4.js
@@ -1,0 +1,3 @@
+/* https://gist.github.com/jed/982883 */
+const crypto = require('crypto')
+module.exports = a=>a?(a^(crypto.randomBytes(1)[0] % 16)>>a/4).toString(16):([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g,module.exports);


### PR DESCRIPTION
Using a simple and secure, small uuidv4 generator.
Saves 5KB of the library (24KB->19KB)

Signed-off-by: Erica Windisch <erica@iopipe.com>