### PR TITLE
Bump timeout window to 150ms

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -9,7 +9,7 @@ module.exports = function setConfig(configObject) {
     clientId: configObject && (configObject.token || configObject.clientId) || process.env.IOPIPE_TOKEN || process.env.IOPIPE_CLIENTID || '',
     debug: configObject && configObject.debug || process.env.IOPIPE_DEBUG || false,
     networkTimeout: configObject && configObject.networkTimeout || 5000,
-    timeoutWindow: configObject && configObject.timeoutWindow || 50,
+    timeoutWindow: configObject && configObject.timeoutWindow || 150,
     installMethod: configObject && configObject.installMethod || process.env.IOPIPE_INSTALL_METHOD || "manual"
   }
 }


### PR DESCRIPTION
Tests show that average coldstart
report building & HTTP communications
take 83ms. Providing some room for outliers,
suggesting 150ms for the default timeout.

Signed-off-by: Erica Windisch <erica@iopipe.com>