### PR TITLE
Add `engines` to package.json to specify minimum version of node 4.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/iopipe/iopipe/issues"
   },
   "homepage": "https://github.com/iopipe/iopipe#readme",
+  "engines": {
+    "node": ">=4.3.2"
+  },
   "devDependencies": {
     "aws-lambda-mock-context": "^3.0.0",
     "babel-core": "^6.25.0",


### PR DESCRIPTION
Closes #154