### PR TITLE
Add timestamp for invocation start

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-jest": "^20.0.3",
     "eslint-plugin-prettier": "^2.1.2",
     "flat": "^2.0.1",
-    "iopipe-payload": "^1.4.0",
     "is-ip": "^2.0.0",
     "istanbul": "^0.4.4",
     "jest": "^20.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,7 @@ class IOpipeWrapperClass {
     originalCallback
   ) {
     this.startTime = process.hrtime();
+    this.startTimestamp = Date.now();
 
     // setup any included plugins
     this.plugins = plugins.map((pluginFn = defaultPluginFunction) => {

--- a/src/report.js
+++ b/src/report.js
@@ -24,7 +24,8 @@ class Report {
       context = {},
       dnsPromise = Promise.resolve(),
       metrics = [],
-      startTime = process.hrtime()
+      startTime = process.hrtime(),
+      startTimestamp = Date.now()
     } = wrapperInstance;
 
     this.config = config;
@@ -48,6 +49,7 @@ class Report {
       installMethod: this.config.installMethod,
       duration: undefined,
       processId: globals.PROCESS_ID,
+      timestamp: startTimestamp,
       aws: {
         functionName,
         functionVersion,

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import flatten from 'flat';
 import Report from './report';
 import context from 'aws-lambda-mock-context';
-import { PAYLOAD_SCHEMA as schema } from 'iopipe-payload';
+const schema = require('./schema.json');
 
 const config = {
   clientId: 'foo'
@@ -31,12 +31,18 @@ describe('Report creation', () => {
       const flatSchema = _.chain(schema).thru(flatten).keys().value();
       const diff = _.difference(flatSchema, flatReport);
       const allowedMissingFields = [
+        'projectId',
         'memory.rssMiB',
         'memory.totalMiB',
         'memory.rssTotalPercentage',
         'environment.python.version',
         'errors.stackHash',
-        'errors.count'
+        'errors.count',
+        'performanceEntries.0.name',
+        'performanceEntries.0.startTime',
+        'performanceEntries.0.duration',
+        'performanceEntries.0.entryType',
+        'performanceEntries.0.timestamp'
       ];
       expect(_.isEqual(allowedMissingFields, diff)).toBe(true);
       done();

--- a/src/schema.json
+++ b/src/schema.json
@@ -1,0 +1,107 @@
+{
+  "client_id": "s",
+  "projectId": "s",
+  "installMethod": "s",
+  "duration": "i",
+  "processId": "s",
+  "timestamp": "n",
+  "aws": {
+    "functionName": "s",
+    "functionVersion": "s",
+    "awsRequestId": "s",
+    "invokedFunctionArn": "s",
+    "logGroupName": "s",
+    "logStreamName": "s",
+    "memoryLimitInMB": "n",
+    "getRemainingTimeInMillis": "n",
+    "traceId": "s"
+  },
+  "memory": {
+    "rssMiB": "n",
+    "totalMiB": "n",
+    "rssTotalPercentage": "n"
+  },
+  "environment": {
+    "agent": {
+      "runtime": "s",
+      "version": "s",
+      "load_time": "n"
+    },
+    "nodejs": {
+      "version": "s",
+      "memoryUsage": {
+        "rss": "n"
+      }
+    },
+    "python": {
+      "version": "s"
+    },
+    "host": {
+      "boot_id": "s"
+    },
+    "os": {
+      "hostname": "s",
+      "totalmem": "n",
+      "freemem": "n",
+      "usedmem": "n",
+      "cpus": [
+        {
+          "times": {
+            "idle": "n",
+            "irq": "n",
+            "sys": "n",
+            "user": "n",
+            "nice": "n"
+          }
+        }
+      ],
+      "linux": {
+        "pid": {
+          "self": {
+            "stat": {
+              "utime": "n",
+              "stime": "n",
+              "cutime": "n",
+              "cstime": "n"
+            },
+            "stat_start": {
+              "utime": "n",
+              "stime": "n",
+              "cutime": "n",
+              "cstime": "n"
+            },
+            "status": {
+              "VmRSS": "n",
+              "Threads": "n",
+              "FDSize": "n"
+            }
+          }
+        }
+      }
+    }
+  },
+  "errors": {
+    "stack": "s",
+    "name": "s",
+    "message": "s",
+    "stackHash": "s",
+    "count": "n"
+  },
+  "coldstart": "b",
+  "custom_metrics": [
+    {
+      "name": "s",
+      "s": "s",
+      "n": "n"
+    }
+  ],
+  "performanceEntries": [
+    {
+      "name": "s",
+      "startTime": "n",
+      "duration": "n",
+      "entryType": "s",
+      "timestamp": "n"
+    }
+  ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1918,12 +1918,6 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-iopipe-payload@^1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/iopipe-payload/-/iopipe-payload-1.4.0.tgz#aec7308261b35d0948cdee7b8a2c3673c22f77b5"
-  dependencies:
-    lodash "^4.17.4"
-
 ip-regex@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-2.1.0.tgz#fa78bf5d2e6913c911ce9f819ee5146bb6d844e9"


### PR DESCRIPTION
Adds timestamp at the start of the invocation to the payload. Also updates tests to use a local schema file and removes the npm dependency.