### PR TITLE
Adding `plugins` to report payload

### DIFF
--- a/src/__snapshots__/plugins.test.js.snap
+++ b/src/__snapshots__/plugins.test.js.snap
@@ -25,11 +25,11 @@ Array [
 exports[`Multiple plugins can be loaded and work 1`] = `
 Array [
   Object {
-    "name": "trace-ok",
+    "name": "dummy-ok",
     "s": "neat",
   },
   Object {
-    "name": "trace-foo",
+    "name": "dummy-foo",
     "s": "bar",
   },
 ]

--- a/src/__snapshots__/plugins.test.js.snap
+++ b/src/__snapshots__/plugins.test.js.snap
@@ -25,11 +25,11 @@ Array [
 exports[`Multiple plugins can be loaded and work 1`] = `
 Array [
   Object {
-    "name": "dummy-ok",
+    "name": "mock-ok",
     "s": "neat",
   },
   Object {
-    "name": "dummy-foo",
+    "name": "mock-foo",
     "s": "bar",
   },
 ]

--- a/src/plugins.test.js
+++ b/src/plugins.test.js
@@ -7,7 +7,7 @@ jest.mock('./sendReport');
 import { reports } from './sendReport';
 import { hooks } from './hooks';
 
-import TracePlugin from './plugins/trace';
+import DummyPlugin from './plugins/dummy';
 import {
   instantiate as AllHooksPlugin,
   data as allHooksData
@@ -19,7 +19,7 @@ test('Hooks have not changed', () => {
 });
 
 test('Can instantiate a test plugin', done => {
-  const plugin = TracePlugin();
+  const plugin = DummyPlugin();
 
   const invocationInstance = {};
   const pluginInstance = plugin(invocationInstance);
@@ -30,7 +30,7 @@ test('Can instantiate a test plugin', done => {
 });
 
 test('Can instantiate a test plugin with config', done => {
-  const plugin = TracePlugin({
+  const plugin = DummyPlugin({
     foo: 'bar'
   });
 
@@ -43,7 +43,7 @@ test('Can instantiate a test plugin with config', done => {
 });
 
 test('Can call a plugin hook function', done => {
-  const plugin = TracePlugin();
+  const plugin = DummyPlugin();
 
   const invocationInstance = {
     context: {
@@ -60,21 +60,21 @@ test('Can call a plugin hook function', done => {
 });
 
 test('Can run a test plugin hook that modifies a invocation instance', done => {
-  const plugin = TracePlugin();
+  const plugin = DummyPlugin();
 
   const invocationInstance = { context: { iopipe: { log: _.noop } } };
   const pluginInstance = plugin(invocationInstance);
 
-  expect(_.isFunction(invocationInstance.context.iopipe.trace)).toBe(false);
+  expect(_.isFunction(invocationInstance.context.iopipe.dummy)).toBe(false);
   pluginInstance.hooks['post:setup']();
   expect(pluginInstance.hasSetup).toEqual(true);
-  expect(_.isFunction(invocationInstance.context.iopipe.trace)).toBe(true);
+  expect(_.isFunction(invocationInstance.context.iopipe.dummy)).toBe(true);
 
   done();
 });
 
 test('Can run a test plugin hook directly', done => {
-  const plugin = TracePlugin();
+  const plugin = DummyPlugin();
 
   const invocationInstance = {
     metrics: [
@@ -90,14 +90,14 @@ test('Can run a test plugin hook directly', done => {
   const pluginInstance = plugin(invocationInstance);
 
   pluginInstance.hooks['post:setup']();
-  invocationInstance.context.iopipe.trace('metric-2', 'baz');
+  invocationInstance.context.iopipe.dummy('metric-2', 'baz');
   const { metrics } = invocationInstance;
   expect(metrics.length).toBe(2);
   expect(
     _.find(metrics, m => m.name === 'ding' && m.s === 'dong')
   ).toBeTruthy();
   expect(
-    _.find(metrics, m => m.name === 'trace-metric-2' && m.s === 'baz')
+    _.find(metrics, m => m.name === 'dummy-metric-2' && m.s === 'baz')
   ).toBeTruthy();
 
   done();
@@ -107,12 +107,12 @@ test('A single plugin can be loaded and work', async () => {
   try {
     const iopipe = IOpipe({
       token: 'single-plugin',
-      plugins: [TracePlugin()]
+      plugins: [DummyPlugin()]
     });
 
     const wrapped = iopipe((event, ctx) => {
-      ctx.iopipe.trace('ok', 'neat');
-      ctx.succeed(ctx.iopipe.trace);
+      ctx.iopipe.dummy('ok', 'neat');
+      ctx.succeed(ctx.iopipe.dummy);
     });
 
     const context = mockContext();
@@ -125,7 +125,7 @@ test('A single plugin can be loaded and work', async () => {
     const metric = _.chain(reports)
       .find(obj => obj.client_id === 'single-plugin')
       .get('custom_metrics')
-      .find({ name: 'trace-ok', s: 'neat' })
+      .find({ name: 'dummy-ok', s: 'neat' })
       .value();
     expect(_.isObject(metric)).toBe(true);
   } catch (err) {
@@ -139,16 +139,16 @@ test('Multiple plugins can be loaded and work', async () => {
     const iopipe = IOpipe({
       token: 'multiple-plugins',
       plugins: [
-        TracePlugin(),
-        TracePlugin({
-          functionName: 'secondTrace'
+        DummyPlugin(),
+        DummyPlugin({
+          functionName: 'secondDummy'
         })
       ]
     });
 
     const wrapped = iopipe((event, ctx) => {
-      ctx.iopipe.trace('ok', 'neat');
-      ctx.iopipe.secondTrace('foo', 'bar');
+      ctx.iopipe.dummy('ok', 'neat');
+      ctx.iopipe.secondDummy('foo', 'bar');
       ctx.succeed('indeed');
     });
 

--- a/src/plugins.test.js
+++ b/src/plugins.test.js
@@ -7,7 +7,7 @@ jest.mock('./sendReport');
 import { reports } from './sendReport';
 import { hooks } from './hooks';
 
-import DummyPlugin from './plugins/dummy';
+import MockPlugin from './plugins/mock';
 import {
   instantiate as AllHooksPlugin,
   data as allHooksData
@@ -19,7 +19,7 @@ test('Hooks have not changed', () => {
 });
 
 test('Can instantiate a test plugin', done => {
-  const plugin = DummyPlugin();
+  const plugin = MockPlugin();
 
   const invocationInstance = {};
   const pluginInstance = plugin(invocationInstance);
@@ -30,7 +30,7 @@ test('Can instantiate a test plugin', done => {
 });
 
 test('Can instantiate a test plugin with config', done => {
-  const plugin = DummyPlugin({
+  const plugin = MockPlugin({
     foo: 'bar'
   });
 
@@ -43,7 +43,7 @@ test('Can instantiate a test plugin with config', done => {
 });
 
 test('Can call a plugin hook function', done => {
-  const plugin = DummyPlugin();
+  const plugin = MockPlugin();
 
   const invocationInstance = {
     context: {
@@ -60,21 +60,21 @@ test('Can call a plugin hook function', done => {
 });
 
 test('Can run a test plugin hook that modifies a invocation instance', done => {
-  const plugin = DummyPlugin();
+  const plugin = MockPlugin();
 
   const invocationInstance = { context: { iopipe: { log: _.noop } } };
   const pluginInstance = plugin(invocationInstance);
 
-  expect(_.isFunction(invocationInstance.context.iopipe.dummy)).toBe(false);
+  expect(_.isFunction(invocationInstance.context.iopipe.mock)).toBe(false);
   pluginInstance.hooks['post:setup']();
   expect(pluginInstance.hasSetup).toEqual(true);
-  expect(_.isFunction(invocationInstance.context.iopipe.dummy)).toBe(true);
+  expect(_.isFunction(invocationInstance.context.iopipe.mock)).toBe(true);
 
   done();
 });
 
 test('Can run a test plugin hook directly', done => {
-  const plugin = DummyPlugin();
+  const plugin = MockPlugin();
 
   const invocationInstance = {
     metrics: [
@@ -90,14 +90,14 @@ test('Can run a test plugin hook directly', done => {
   const pluginInstance = plugin(invocationInstance);
 
   pluginInstance.hooks['post:setup']();
-  invocationInstance.context.iopipe.dummy('metric-2', 'baz');
+  invocationInstance.context.iopipe.mock('metric-2', 'baz');
   const { metrics } = invocationInstance;
   expect(metrics.length).toBe(2);
   expect(
     _.find(metrics, m => m.name === 'ding' && m.s === 'dong')
   ).toBeTruthy();
   expect(
-    _.find(metrics, m => m.name === 'dummy-metric-2' && m.s === 'baz')
+    _.find(metrics, m => m.name === 'mock-metric-2' && m.s === 'baz')
   ).toBeTruthy();
 
   done();
@@ -107,12 +107,12 @@ test('A single plugin can be loaded and work', async () => {
   try {
     const iopipe = IOpipe({
       token: 'single-plugin',
-      plugins: [DummyPlugin()]
+      plugins: [MockPlugin()]
     });
 
     const wrapped = iopipe((event, ctx) => {
-      ctx.iopipe.dummy('ok', 'neat');
-      ctx.succeed(ctx.iopipe.dummy);
+      ctx.iopipe.mock('ok', 'neat');
+      ctx.succeed(ctx.iopipe.mock);
     });
 
     const context = mockContext();
@@ -125,7 +125,7 @@ test('A single plugin can be loaded and work', async () => {
     const metric = _.chain(reports)
       .find(obj => obj.client_id === 'single-plugin')
       .get('custom_metrics')
-      .find({ name: 'dummy-ok', s: 'neat' })
+      .find({ name: 'mock-ok', s: 'neat' })
       .value();
     expect(_.isObject(metric)).toBe(true);
 
@@ -133,7 +133,7 @@ test('A single plugin can be loaded and work', async () => {
       .find(obj => obj.client_id === 'single-plugin')
       .get('plugins')
       .find({
-        name: 'dummy',
+        name: 'mock',
         version: '0.0.1',
         homepage: 'https://github.com/not/a/real/plugin'
       })
@@ -151,16 +151,16 @@ test('Multiple plugins can be loaded and work', async () => {
     const iopipe = IOpipe({
       token: 'multiple-plugins',
       plugins: [
-        DummyPlugin(),
-        DummyPlugin({
-          functionName: 'secondDummy'
+        MockPlugin(),
+        MockPlugin({
+          functionName: 'secondmock'
         })
       ]
     });
 
     const wrapped = iopipe((event, ctx) => {
-      ctx.iopipe.dummy('ok', 'neat');
-      ctx.iopipe.secondDummy('foo', 'bar');
+      ctx.iopipe.mock('ok', 'neat');
+      ctx.iopipe.secondmock('foo', 'bar');
       ctx.succeed('indeed');
     });
 

--- a/src/plugins.test.js
+++ b/src/plugins.test.js
@@ -128,6 +128,18 @@ test('A single plugin can be loaded and work', async () => {
       .find({ name: 'dummy-ok', s: 'neat' })
       .value();
     expect(_.isObject(metric)).toBe(true);
+
+    const plugin = _.chain(reports)
+      .find(obj => obj.client_id === 'single-plugin')
+      .get('plugins')
+      .find({
+        name: 'dummy',
+        version: '0.0.1',
+        homepage: 'https://github.com/not/a/real/plugin'
+      })
+      .value();
+
+    expect(_.isObject(plugin)).toBe(true);
   } catch (err) {
     console.error(err);
     throw err;

--- a/src/plugins/allHooks.js
+++ b/src/plugins/allHooks.js
@@ -16,14 +16,9 @@ class AllHooksPlugin {
       })
       .fromPairs()
       .value();
-    this.meta = {
-      name: 'allHooks',
-      version: '0.0.1',
-      homepage: 'https://github.com/not/a/real/plugin'
-    };
     return this;
   }
-  meta() {
+  get meta() {
     return {
       name: 'allHooks',
       version: '0.0.1',

--- a/src/plugins/allHooks.js
+++ b/src/plugins/allHooks.js
@@ -23,6 +23,13 @@ class AllHooksPlugin {
     };
     return this;
   }
+  meta() {
+    return {
+      name: 'allHooks',
+      version: '0.0.1',
+      homepage: 'https://github.com/not/a/real/plugin'
+    };
+  }
   runHook(hook) {
     const str = `context.hasRun:${hook}`;
     _.set(this.invocationInstance, str, true);

--- a/src/plugins/allHooks.js
+++ b/src/plugins/allHooks.js
@@ -7,7 +7,7 @@ class AllHooksPlugin {
   constructor(pluginConfig = {}, invocationInstance) {
     this.invocationInstance = invocationInstance;
     this.config = _.defaults({}, pluginConfig, {
-      functionName: 'trace'
+      functionName: 'allHooks'
     });
     this.hasSetup = false;
     this.hooks = _.chain(hooks)
@@ -16,6 +16,11 @@ class AllHooksPlugin {
       })
       .fromPairs()
       .value();
+    this.meta = {
+      name: 'allHooks',
+      version: '0.0.1',
+      homepage: 'https://github.com/not/a/real/plugin'
+    };
     return this;
   }
   runHook(hook) {

--- a/src/plugins/dummy.js
+++ b/src/plugins/dummy.js
@@ -12,7 +12,7 @@ class DummyPlugin {
     };
     return this;
   }
-  meta() {
+  get meta() {
     return {
       name: 'dummy',
       version: '0.0.1',

--- a/src/plugins/dummy.js
+++ b/src/plugins/dummy.js
@@ -1,14 +1,19 @@
 import _ from 'lodash';
 
-class TracePlugin {
+class DummyPlugin {
   constructor(pluginConfig = {}, invocationInstance) {
     this.invocationInstance = invocationInstance;
     this.config = _.defaults({}, pluginConfig, {
-      functionName: 'trace'
+      functionName: 'dummy'
     });
     this.hasSetup = false;
     this.hooks = {
       'post:setup': this.postSetup.bind(this)
+    };
+    this.meta = {
+      name: 'dummy',
+      version: '0.0.1',
+      homepage: 'https://github.com/not/a/real/plugin'
     };
     return this;
   }
@@ -16,13 +21,13 @@ class TracePlugin {
     this.hasSetup = true;
     this.invocationInstance.context.iopipe[
       this.config.functionName
-    ] = this.trace.bind(this);
+    ] = this.dummy.bind(this);
     return this.config;
   }
-  trace(name, s) {
+  dummy(name, s) {
     const { metrics = [] } = this.invocationInstance;
     metrics.push({
-      name: `trace-${name}`,
+      name: `dummy-${name}`,
       s
     });
   }
@@ -30,6 +35,6 @@ class TracePlugin {
 
 export default function instantiate(pluginOpts) {
   return invocationInstance => {
-    return new TracePlugin(pluginOpts, invocationInstance);
+    return new DummyPlugin(pluginOpts, invocationInstance);
   };
 }

--- a/src/plugins/dummy.js
+++ b/src/plugins/dummy.js
@@ -10,12 +10,14 @@ class DummyPlugin {
     this.hooks = {
       'post:setup': this.postSetup.bind(this)
     };
-    this.meta = {
+    return this;
+  }
+  meta() {
+    return {
       name: 'dummy',
       version: '0.0.1',
       homepage: 'https://github.com/not/a/real/plugin'
     };
-    return this;
   }
   postSetup() {
     this.hasSetup = true;

--- a/src/plugins/mock.js
+++ b/src/plugins/mock.js
@@ -1,10 +1,10 @@
 import _ from 'lodash';
 
-class DummyPlugin {
+class MockPlugin {
   constructor(pluginConfig = {}, invocationInstance) {
     this.invocationInstance = invocationInstance;
     this.config = _.defaults({}, pluginConfig, {
-      functionName: 'dummy'
+      functionName: 'mock'
     });
     this.hasSetup = false;
     this.hooks = {
@@ -14,7 +14,7 @@ class DummyPlugin {
   }
   get meta() {
     return {
-      name: 'dummy',
+      name: 'mock',
       version: '0.0.1',
       homepage: 'https://github.com/not/a/real/plugin'
     };
@@ -23,13 +23,13 @@ class DummyPlugin {
     this.hasSetup = true;
     this.invocationInstance.context.iopipe[
       this.config.functionName
-    ] = this.dummy.bind(this);
+    ] = this.mock.bind(this);
     return this.config;
   }
-  dummy(name, s) {
+  mock(name, s) {
     const { metrics = [] } = this.invocationInstance;
     metrics.push({
-      name: `dummy-${name}`,
+      name: `mock-${name}`,
       s
     });
   }
@@ -37,6 +37,6 @@ class DummyPlugin {
 
 export default function instantiate(pluginOpts) {
   return invocationInstance => {
-    return new DummyPlugin(pluginOpts, invocationInstance);
+    return new MockPlugin(pluginOpts, invocationInstance);
   };
 }

--- a/src/report.js
+++ b/src/report.js
@@ -45,7 +45,22 @@ class Report {
       memoryLimitInMB
     } = this.context;
 
-    const pluginMetas = plugins.map(plugin => plugin.meta);
+    const pluginMetas = plugins
+      .map(plugin => {
+        if (typeof plugin === 'function') {
+          return plugin().meta;
+        }
+
+        return plugin.meta;
+      })
+      .filter(meta => typeof meta !== 'undefined')
+      .map(meta => {
+        return {
+          name: meta.name,
+          version: meta.version,
+          homepage: meta.homepage
+        };
+      });
 
     this.report = {
       client_id: this.config.clientId || undefined,

--- a/src/report.js
+++ b/src/report.js
@@ -24,6 +24,7 @@ class Report {
       context = {},
       dnsPromise = Promise.resolve(),
       metrics = [],
+      plugins = [],
       startTime = process.hrtime(),
       startTimestamp = Date.now()
     } = wrapperInstance;
@@ -43,6 +44,8 @@ class Report {
       logStreamName,
       memoryLimitInMB
     } = this.context;
+
+    const pluginConfigss = plugins.map(pluginFn => pluginFn.config);
 
     this.report = {
       client_id: this.config.clientId || undefined,
@@ -78,7 +81,8 @@ class Report {
       },
       errors: {},
       coldstart: globals.COLDSTART,
-      custom_metrics: metrics
+      custom_metrics: metrics,
+      plugins: pluginConfigss
     };
 
     // Set to false after coldstart

--- a/src/report.js
+++ b/src/report.js
@@ -45,7 +45,9 @@ class Report {
       memoryLimitInMB
     } = this.context;
 
-    const pluginConfigss = plugins.map(pluginFn => pluginFn.config);
+    const pluginConfigss = plugins.map(pluginFn => {
+      return { name: pluginFn.config.functionName };
+    });
 
     this.report = {
       client_id: this.config.clientId || undefined,

--- a/src/report.js
+++ b/src/report.js
@@ -46,21 +46,11 @@ class Report {
     } = this.context;
 
     const pluginMetas = plugins
-      .map(plugin => {
-        if (typeof plugin === 'function') {
-          return plugin().meta;
-        }
-
-        return plugin.meta;
-      })
-      .filter(meta => typeof meta !== 'undefined')
-      .map(meta => {
-        return {
-          name: meta.name,
-          version: meta.version,
-          homepage: meta.homepage
-        };
-      });
+      .filter(
+        plugin =>
+          typeof plugin !== 'undefined' && typeof plugin.meta === 'function'
+      )
+      .map(plugin => plugin.meta());
 
     this.report = {
       client_id: this.config.clientId || undefined,

--- a/src/report.js
+++ b/src/report.js
@@ -46,11 +46,8 @@ class Report {
     } = this.context;
 
     const pluginMetas = plugins
-      .filter(
-        plugin =>
-          typeof plugin !== 'undefined' && typeof plugin.meta === 'function'
-      )
-      .map(plugin => plugin.meta());
+      .filter(plugin => typeof plugin !== 'undefined')
+      .map(plugin => plugin.meta || {});
 
     this.report = {
       client_id: this.config.clientId || undefined,

--- a/src/report.js
+++ b/src/report.js
@@ -45,9 +45,7 @@ class Report {
       memoryLimitInMB
     } = this.context;
 
-    const pluginConfigs = plugins.map(pluginFn => {
-      return { name: pluginFn.config.functionName };
-    });
+    const pluginMetas = plugins.map(plugin => plugin.meta);
 
     this.report = {
       client_id: this.config.clientId || undefined,
@@ -84,7 +82,7 @@ class Report {
       errors: {},
       coldstart: globals.COLDSTART,
       custom_metrics: metrics,
-      plugins: pluginConfigs
+      plugins: pluginMetas
     };
 
     // Set to false after coldstart

--- a/src/report.js
+++ b/src/report.js
@@ -45,7 +45,7 @@ class Report {
       memoryLimitInMB
     } = this.context;
 
-    const pluginConfigss = plugins.map(pluginFn => {
+    const pluginConfigs = plugins.map(pluginFn => {
       return { name: pluginFn.config.functionName };
     });
 
@@ -84,7 +84,7 @@ class Report {
       errors: {},
       coldstart: globals.COLDSTART,
       custom_metrics: metrics,
-      plugins: pluginConfigss
+      plugins: pluginConfigs
     };
 
     // Set to false after coldstart

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -44,6 +44,7 @@ describe('Report creation', () => {
         'performanceEntries.0.entryType',
         'performanceEntries.0.timestamp'
       ];
+
       expect(_.isEqual(allowedMissingFields, diff)).toBe(true);
       done();
     });
@@ -55,5 +56,19 @@ describe('Report creation', () => {
     myMetrics.push({ n: 1, name: 'a_value' });
 
     expect(r.report.custom_metrics.length).toBe(1);
+  });
+
+  it('tracks plugins in use', () => {
+    const mockPlugin = () => {
+      return {
+        config: {
+          name: 'mockPlugin'
+        }
+      };
+    };
+    const myPlugins = [mockPlugin()];
+    const r = new Report({ config, context: context(), plugins: myPlugins });
+
+    expect(r.report.plugins.length).toBe(1);
   });
 });

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -62,7 +62,7 @@ describe('Report creation', () => {
     const mockPlugin = () => {
       return {
         config: {
-          name: 'mockPlugin'
+          functionName: 'mockPlugin'
         }
       };
     };
@@ -70,5 +70,7 @@ describe('Report creation', () => {
     const r = new Report({ config, context: context(), plugins: myPlugins });
 
     expect(r.report.plugins.length).toBe(1);
+
+    expect(r.report.plugins[0].name).toBe('mockPlugin');
   });
 });

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -63,9 +63,17 @@ describe('Report creation', () => {
   });
 
   it('tracks plugins in use', () => {
-    const plugins = [DummyPlugin()];
-    const r = new Report({ config, context: context(), plugins: plugins });
+    const plugin = DummyPlugin();
+    const r = new Report({ plugins: [plugin] });
 
     expect(r.report.plugins.length).toBe(1);
+
+    expect(r.report.plugins[0].name).toBe('dummy');
+
+    expect(r.report.plugins[0].version).toBe('0.0.1');
+
+    expect(r.report.plugins[0].homepage).toBe(
+      'https://github.com/not/a/real/plugin'
+    );
   });
 });

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -42,7 +42,8 @@ describe('Report creation', () => {
         'performanceEntries.0.startTime',
         'performanceEntries.0.duration',
         'performanceEntries.0.entryType',
-        'performanceEntries.0.timestamp'
+        'performanceEntries.0.timestamp',
+        'plugins.0.name'
       ];
 
       expect(_.isEqual(allowedMissingFields, diff)).toBe(true);

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -64,7 +64,8 @@ describe('Report creation', () => {
 
   it('tracks plugins in use', () => {
     const plugin = DummyPlugin();
-    const r = new Report({ plugins: [plugin] });
+
+    const r = new Report({ plugins: [plugin()] });
 
     expect(r.report.plugins.length).toBe(1);
 

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import flatten from 'flat';
 import Report from './report';
 import context from 'aws-lambda-mock-context';
-import DummyPlugin from './plugins/dummy';
+import MockPlugin from './plugins/mock';
 const schema = require('./schema.json');
 
 const config = {
@@ -63,13 +63,13 @@ describe('Report creation', () => {
   });
 
   it('tracks plugins in use', () => {
-    const plugin = DummyPlugin();
+    const plugin = MockPlugin();
 
     const r = new Report({ plugins: [plugin()] });
 
     expect(r.report.plugins.length).toBe(1);
 
-    expect(r.report.plugins[0].name).toBe('dummy');
+    expect(r.report.plugins[0].name).toBe('mock');
 
     expect(r.report.plugins[0].version).toBe('0.0.1');
 

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import flatten from 'flat';
 import Report from './report';
 import context from 'aws-lambda-mock-context';
+import DummyPlugin from './plugins/dummy';
 const schema = require('./schema.json');
 
 const config = {
@@ -43,7 +44,9 @@ describe('Report creation', () => {
         'performanceEntries.0.duration',
         'performanceEntries.0.entryType',
         'performanceEntries.0.timestamp',
-        'plugins.0.name'
+        'plugins.0.name',
+        'plugins.0.version',
+        'plugins.0.homepage'
       ];
 
       expect(_.isEqual(allowedMissingFields, diff)).toBe(true);
@@ -60,18 +63,9 @@ describe('Report creation', () => {
   });
 
   it('tracks plugins in use', () => {
-    const mockPlugin = () => {
-      return {
-        config: {
-          functionName: 'mockPlugin'
-        }
-      };
-    };
-    const myPlugins = [mockPlugin()];
-    const r = new Report({ config, context: context(), plugins: myPlugins });
+    const plugins = [DummyPlugin()];
+    const r = new Report({ config, context: context(), plugins: plugins });
 
     expect(r.report.plugins.length).toBe(1);
-
-    expect(r.report.plugins[0].name).toBe('mockPlugin');
   });
 });

--- a/src/schema.json
+++ b/src/schema.json
@@ -103,5 +103,10 @@
       "entryType": "s",
       "timestamp": "n"
     }
+  ],
+  "plugins": [
+    {
+      "name": "s"
+    }
   ]
 }

--- a/src/schema.json
+++ b/src/schema.json
@@ -106,7 +106,9 @@
   ],
   "plugins": [
     {
-      "name": "s"
+      "name": "s",
+      "version": "s",
+      "homepage": "s"
     }
   ]
 }


### PR DESCRIPTION
A plugin has a `functionName`, wouldn't just `name` be better for this purpose? That way it isn't confused with the lambda's `functionName`.

Also, thinking a `version` property for a plugin might be worth tracking.