### PR TITLE
Add enabled flag for plugins

### DIFF
--- a/src/plugins/allHooks.js
+++ b/src/plugins/allHooks.js
@@ -22,7 +22,8 @@ class AllHooksPlugin {
     return {
       name: 'allHooks',
       version: '0.0.1',
-      homepage: 'https://github.com/not/a/real/plugin'
+      homepage: 'https://github.com/not/a/real/plugin',
+      enabled: false
     };
   }
   runHook(hook) {

--- a/src/plugins/mock.js
+++ b/src/plugins/mock.js
@@ -19,7 +19,8 @@ class MockPlugin {
     return {
       name: 'mock',
       version: '0.0.1',
-      homepage: 'https://github.com/not/a/real/plugin'
+      homepage: 'https://github.com/not/a/real/plugin',
+      enabled: true
     };
   }
   postSetup() {

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -52,7 +52,8 @@ describe('Report creation', () => {
         'performanceEntries.0.timestamp',
         'plugins.0.name',
         'plugins.0.version',
-        'plugins.0.homepage'
+        'plugins.0.homepage',
+        'plugins.0.enabled'
       ];
 
       expect(_.isEqual(allowedMissingFields, diff)).toBe(true);

--- a/src/schema.json
+++ b/src/schema.json
@@ -109,7 +109,8 @@
     {
       "name": "s",
       "version": "s",
-      "homepage": "s"
+      "homepage": "s",
+      "enabled": "b"
     }
   ]
 }


### PR DESCRIPTION
Plugins, such as the profiling plugin, can report their enabled/disabled state in their plugin metadata.