### PR TITLE
Fix timeout race condition and add test

### DIFF
--- a/src/__mocks__/sendReport.js
+++ b/src/__mocks__/sendReport.js
@@ -3,15 +3,19 @@ import _ from 'lodash';
 const reports = [];
 
 function sendReport(requestBody, config, ipAddress) {
-  const data = _.assign({}, requestBody, {
-    _meta: {
-      config,
-      ipAddress
-    }
-  });
-  reports.push(data);
-  return Promise.resolve({
-    status: 200
+  return new Promise(resolve => {
+    const data = _.assign({}, requestBody, {
+      _meta: {
+        config,
+        ipAddress
+      }
+    });
+    setTimeout(() => {
+      reports.push(data);
+      resolve({
+        status: 200
+      });
+    }, 10);
   });
 }
 

--- a/src/__mocks__/sendReport.js
+++ b/src/__mocks__/sendReport.js
@@ -10,6 +10,8 @@ function sendReport(requestBody, config, ipAddress) {
         ipAddress
       }
     });
+    // use a timeout to emulate some amount of network latency for the report send
+    // especially useful for class.test.js - proper timeout reporting
     setTimeout(() => {
       reports.push(data);
       resolve({

--- a/src/index.js
+++ b/src/index.js
@@ -140,13 +140,13 @@ class IOpipeWrapperClass {
   async sendReport(err, cb = () => {}) {
     await this.runHook('post:invoke');
     await this.runHook('pre:report');
-    // reset the context back to its original state
-    this.setupContext(true);
     if (this.timeout) {
       clearTimeout(this.timeout);
     }
     this.report.send(err, async (...args) => {
       await this.runHook('post:report');
+      // reset the context back to its original state, otherwise aws gets unhappy
+      this.setupContext(true);
       cb(...args);
     });
   }


### PR DESCRIPTION
The issue:
When the agent believes the lambda will time out, it sends the report. During the time the report is sending, if the code calls a `context.succeed` equivalent, it is successful. We want the lambda to effectively hit the timeout that it normally would.

The fix:
Reset the context back to the original one (for aws reasons) as late as we can during the execution.