### PR TITLE
Whitelist babel requires for webpacking

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.0",
+    "babel-runtime": "^6.26.0",
     "coveralls": "^2.11.12",
     "delay": "^2.0.0",
     "eslint": "^3.12.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ module.exports = {
   plugins: _.compact([process.env.ANALYZE && new BundleAnalyzerPlugin()]),
   externals: [
     nodeExternals({
-      whitelist: [/babel\-runtime/, /regenerator\-runtime/, /core\-js/]
+      whitelist: [/babel-runtime/, /regenerator-runtime/, /core-js/]
     })
   ],
   module: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,11 @@ module.exports = {
     library: 'iopipe'
   },
   plugins: _.compact([process.env.ANALYZE && new BundleAnalyzerPlugin()]),
-  externals: [nodeExternals()],
+  externals: [
+    nodeExternals({
+      whitelist: [/babel\-runtime/, /regenerator\-runtime/, /core\-js/]
+    })
+  ],
   module: {
     rules: [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -711,6 +711,13 @@ babel-runtime@^6.18.0, babel-runtime@^6.22.0:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
 
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
+
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.25.0.tgz#665241166b7c2aa4c619d71e192969552b10c071"
@@ -3414,6 +3421,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
 
 regenerator-transform@0.9.11:
   version "0.9.11"


### PR DESCRIPTION
Otherwise they are left out of the build - and they aren't listed as dependencies so runtime (lambda) will fail execution.