### PR TITLE
WIP Updating cosmiconfig loading to load from __dirname

### DIFF
--- a/src/config/util.js
+++ b/src/config/util.js
@@ -9,10 +9,18 @@ function getCosmiConfig() {
       cache: false,
       sync: true,
       rcExtensions: true
-    }).load(process.cwd());
+    });
 
-    if (config !== null) {
-      return config.config;
+    const localConfig = config.load(process.cwd());
+
+    if (localConfig !== null) {
+      return localConfig.config;
+    }
+
+    const globalConfig = config.load(__dirname);
+
+    if (globalConfig !== null) {
+      return globalConfig.config;
     }
   } catch (err) {
     void 0; // noop

--- a/src/config/util.js
+++ b/src/config/util.js
@@ -13,13 +13,13 @@ function getCosmiConfig() {
 
     const localConfig = config.load(process.cwd());
 
-    if (localConfig !== null) {
+    if (localConfig && localConfig.config) {
       return localConfig.config;
     }
 
     const globalConfig = config.load(__dirname);
 
-    if (globalConfig !== null) {
+    if (globalConfig && globalConfig.config) {
       return globalConfig.config;
     }
   } catch (err) {


### PR DESCRIPTION
This updates the `getCosmiConfig` utility to attempt to load cosmiconfig from `__dirname` if `process.cwd` doesn't find anything. This way `__dirname` is only traversed if nothing is found in the current working directory chain.