### PR TITLE
Making package public, adding .npmrc based npm auth

### DIFF
--- a/.npmrc-sample
+++ b/.npmrc-sample
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/circle.yml
+++ b/circle.yml
@@ -18,9 +18,8 @@ deployment:
     owner: iopipe
     commands:
       - npm run build
-      # login using environment variables
-      - echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
-      - npm publish
+      - cp .npmrc-sample .npmrc
+      - npm publish --access public
 
   acceptanceTests:
     branch: master


### PR DESCRIPTION
Org packages are private by default, adding `--access public` flag to make it public.