### PR TITLE
Adding a warning if a requireFromString fails

### DIFF
--- a/src/config/util.js
+++ b/src/config/util.js
@@ -39,9 +39,10 @@ function requireFromString(src, args) {
     if (args && Array.isArray(args)) return mod.apply(null, args);
 
     if (typeof mod === 'function') return mod();
+
     return mod;
   } catch (err) {
-    void 0; // noop
+    console.warn('Failed to import ${src}');
   }
 
   return undefined;


### PR DESCRIPTION
This way a plugin failing to load isn't silenced.