### PR TITLE
fix(warnings): do not warn when known @iopipe/config err occurs

### DIFF
--- a/src/config/util.js
+++ b/src/config/util.js
@@ -42,7 +42,9 @@ function requireFromString(src, args) {
 
     return mod;
   } catch (err) {
-    console.warn('Failed to import ${src}');
+    if (!(err.message || '').match(/Cannot find module \'@iopipe\/config\'/)) {
+      console.warn(`Failed to import ${src}`);
+    }
   }
 
   return undefined;

--- a/testProjects/extendConfig/package-lock.json
+++ b/testProjects/extendConfig/package-lock.json
@@ -5,9 +5,12 @@
   "requires": true,
   "dependencies": {
     "@iopipe/config": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@iopipe/config/-/config-0.1.0.tgz",
-      "integrity": "sha1-LDdkBdYv9GxXdfBT7mWr6qa9MUE="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@iopipe/config/-/config-0.3.0.tgz",
+      "integrity": "sha1-gOFuJt1Ryz+FeoD+ujWvP9THJgE=",
+      "requires": {
+        "@iopipe/trace": "0.3.0"
+      }
     },
     "@iopipe/trace": {
       "version": "0.3.0",

--- a/testProjects/extendConfig/package.json
+++ b/testProjects/extendConfig/package.json
@@ -8,7 +8,7 @@
     "test": "npm run build && jest"
   },
   "dependencies": {
-    "@iopipe/config": "^0.1.0",
+    "@iopipe/config": "^0.3.0",
     "@iopipe/trace": "^0.3.0"
   },
   "iopipe": {

--- a/testProjects/extendConfig/yarn.lock
+++ b/testProjects/extendConfig/yarn.lock
@@ -2,9 +2,11 @@
 # yarn lockfile v1
 
 
-"@iopipe/config@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@iopipe/config/-/config-0.1.0.tgz#2c376405d62ff46c5775f053ee65abeaa6bd3141"
+"@iopipe/config@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@iopipe/config/-/config-0.3.0.tgz#80e16e26dd51cb3f857a80feba35af3fd4c72601"
+  dependencies:
+    "@iopipe/trace" "^0.3.0"
 
 "@iopipe/trace@^0.3.0":
   version "0.3.0"


### PR DESCRIPTION
- Also upgrade @iopipe/config for extendConfig test to drop extraneous console.warn messages related to missing @iopipe/profiler during tests.