### PR TITLE
try/catch require for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ exports.handler = iopipe((event, context, callback) => {
 ```
 
 ## RC File Configuration
+Not recommended for webpack/bundlers due to dynamic require.
 
 You can configure iopipe via an `.iopiperc` RC file. [An example of that is here](https://github.com/iopipe/iopipe-js-core/blob/master/testProjects/rcFileConfig/.iopiperc). Config options are the same as the module instantiation object, except for plugins. Plugins should be an array containing mixed-type values. A plugin value can be a:
 - String that is the name of the plugin
@@ -106,6 +107,7 @@ You can configure iopipe via an `.iopiperc` RC file. [An example of that is here
 **IMPORTANT**: You must install the plugins as dependencies for them to load properly in your environment.
 
 ## package.json Configuration
+Not recommended for webpack/bundlers due to dynamic require.
 
 You can configure iopipe within a `iopipe` package.json entry. [An example of that is here](https://github.com/iopipe/iopipe/blob/master/testProjects/packageJsonConfig/package.json#L10). Config options are the same as the module instantiation object, except for plugins. Plugins should be an array containing mixed-type values. A plugin value can be a:
 - String that is the name of the plugin
@@ -131,6 +133,7 @@ You can configure iopipe within a `iopipe` package.json entry. [An example of th
 **IMPORTANT**: You must install the plugins as dependencies for them to load properly in your environment.
 
 ## Extends Configuration
+Not recommended for webpack/bundlers due to dynamic require.
 
 You can configure iopipe within a package.json or rc file by referencing a `extends` config package. [An example of that is here](https://github.com/iopipe/iopipe-js-core/blob/master/testProjects/extendConfig/package.json#L15). Config options are the same as the module instantiation object, except for plugins. Plugins should be an array containing mixed-type values. A plugin value can be a:
 - String that is the name of the plugin

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "node": ">=4.3.2"
   },
   "devDependencies": {
+    "@iopipe/config": "^0.3.0",
     "@iopipe/trace": "^0.3.0",
     "aws-lambda-mock-context": "^3.0.0",
     "aws-sdk": "^2.164.0",

--- a/src/config/cosmi.js
+++ b/src/config/cosmi.js
@@ -20,7 +20,7 @@ export default class CosmiConfig extends DefaultConfig {
     super();
 
     /* The extends object from the default of @iopipe/config */
-    const defaultExtendsObject = requireFromString(this.extends) || {};
+    const defaultExtendsObject = this.extends || {};
     const cosmiObject = getCosmiConfig() || {};
     /* If someone has {extends: "foo"} in their cosmiConfig (package.json, iopipe.rc) */
     const cosmiExtendsObject = requireFromString(cosmiObject.extends) || {};

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -2,6 +2,13 @@ import collector from './../collector';
 
 const { getHostname, getCollectorPath } = collector;
 
+let iopipeConfig;
+try {
+  iopipeConfig = require('@iopipe/config');
+} catch (err) {
+  // noop
+}
+
 export default class DefaultConfig {
   /**
    * Default configuration
@@ -19,11 +26,7 @@ export default class DefaultConfig {
   }
 
   get extends() {
-    try {
-      return require('@iopipe/config');
-    } catch (err) {
-      return undefined;
-    }
+    return iopipeConfig;
   }
 
   get host() {

--- a/src/config/default.js
+++ b/src/config/default.js
@@ -19,7 +19,11 @@ export default class DefaultConfig {
   }
 
   get extends() {
-    return '@iopipe/config';
+    try {
+      return require('@iopipe/config');
+    } catch (err) {
+      return undefined;
+    }
   }
 
   get host() {

--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -1,6 +1,11 @@
 import setConfig from './index';
 
 jest.mock('./util');
+jest.mock('@iopipe/config', () => {
+  return {
+    plugins: []
+  };
+});
 
 import { setConfigPath } from './util';
 

--- a/testProjects/metaWithExtraPlugins/handler.test.js
+++ b/testProjects/metaWithExtraPlugins/handler.test.js
@@ -24,7 +24,7 @@ describe('Meta with extra plugin, no deduping', () => {
         const { config } = context.iopipe;
         const { plugins } = inspectableInvocation;
 
-        expect(config.extends).toBe('@iopipe/config');
+        expect(config.extends).toEqual({ plugins: ['@iopipe/trace'] });
 
         const names = _.chain(plugins)
           .map(p => p.meta.name)
@@ -65,7 +65,7 @@ describe('Meta with extra plugin, dedupes trace plugin', () => {
         const { config } = context.iopipe;
         const { plugins } = inspectableInvocation;
 
-        expect(config.extends).toBe('@iopipe/config');
+        expect(config.extends).toEqual({ plugins: ['@iopipe/trace'] });
 
         const names = _.chain(plugins)
           .map(p => p.meta.name)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,12 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
+"@iopipe/config@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@iopipe/config/-/config-0.3.0.tgz#80e16e26dd51cb3f857a80feba35af3fd4c72601"
+  dependencies:
+    "@iopipe/trace" "^0.3.0"
+
 "@iopipe/trace@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@iopipe/trace/-/trace-0.3.0.tgz#42a558da9c7d310d15f09fddb490fbb7ebbbf399"


### PR DESCRIPTION
The require of `@iopipe/config` needs to use a statically analyzable `require()` call so consumers who are using webpack do not experience unexpected results.