### PR TITLE
chore(tests): add test for handling typeErrors with lazy-loaded require

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,5 @@ coverage
 acceptance/node_modules
 acceptance/iopipe.js
 .serverless
+node_modules
+iopipe.js

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "acceptanceLocalContextDone": "sls invoke local -f contextDone",
     "acceptanceLocal": "npm run acceptanceLocalCallback && npm run acceptanceLocalContextSuccess && npm run acceptanceLocalContextDone",
     "build": "npm run webpack",
-    "eslint": "eslint src spec acceptance",
+    "eslint": "eslint src spec acceptance testProjects",
     "jest": "jest",
     "prepare": "npm run build",
     "prepublishOnly": "npm run build",
@@ -72,7 +72,8 @@
     "serverless": "^1.24.1",
     "webpack": "^3.2.0",
     "webpack-bundle-analyzer": "^2.9.1",
-    "webpack-node-externals": "^1.6.0"
+    "webpack-node-externals": "^1.6.0",
+    "yargs": "^11.0.0"
   },
   "pre-commit": [
     "test"

--- a/testProjects/catchTypeError/handler.js
+++ b/testProjects/catchTypeError/handler.js
@@ -1,0 +1,7 @@
+/*eslint-disable no-unreachable*/
+
+throw new TypeError('wow-great-type-error');
+
+module.exports = (event, context) => {
+  context.succeed();
+};

--- a/testProjects/catchTypeError/handler.test.js
+++ b/testProjects/catchTypeError/handler.test.js
@@ -1,0 +1,27 @@
+import _ from 'lodash';
+import delay from 'delay';
+
+const iopipe = require('./iopipe');
+
+describe('Catch typeError by wrapping require block', () => {
+  beforeEach(() => {
+    delete process.env.IOPIPE_TOKEN;
+  });
+
+  it('Has configuration', async () => {
+    let inspectableInvocation;
+    iopipe({
+      token: 'test-token',
+      plugins: [
+        inv => {
+          inspectableInvocation = inv;
+        }
+      ]
+    })((event, context) => require('./handler')(event, context))({}, {});
+    await delay(100);
+    const {
+      report: { report: { errors: { message } } }
+    } = inspectableInvocation;
+    expect(message).toMatch('wow-great-type-error');
+  });
+});

--- a/testProjects/catchTypeError/package.json
+++ b/testProjects/catchTypeError/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "catchTypeErrorTest",
+  "version": "0.0.0",
+  "description": "",
+  "main": "handler.test.js",
+  "scripts": {
+    "test": "node ../../node_modules/jest/bin/jest.js"
+  }
+}

--- a/testProjects/extendConfig/handler.test.js
+++ b/testProjects/extendConfig/handler.test.js
@@ -1,17 +1,8 @@
 import _ from 'lodash';
 
-const iopipe = require('./iopipe');
+import { MockPlugin } from '../util/plugins';
 
-class MockPlugin {
-  constructor() {
-    return this;
-  }
-  get meta() {
-    return {
-      name: 'mock-plugin'
-    };
-  }
-}
+const iopipe = require('./iopipe');
 
 describe('Using extend iopipe configuration', () => {
   beforeEach(() => {

--- a/testProjects/metaWithExtraPlugins/handler.test.js
+++ b/testProjects/metaWithExtraPlugins/handler.test.js
@@ -1,29 +1,8 @@
 import _ from 'lodash';
 
+import { MockPlugin, MockTracePlugin } from '../util/plugins';
+
 const iopipe = require('./iopipe');
-
-class MockPlugin {
-  constructor() {
-    return this;
-  }
-  get meta() {
-    return {
-      name: 'mock-plugin'
-    };
-  }
-}
-
-class MockTracePlugin {
-  constructor() {
-    return this;
-  }
-  get meta() {
-    return {
-      name: '@iopipe/trace',
-      version: 'mocked-trace'
-    };
-  }
-}
 
 describe('Meta with extra plugin, no deduping', () => {
   beforeEach(() => {

--- a/testProjects/rcFileConfig/handler.test.js
+++ b/testProjects/rcFileConfig/handler.test.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+import { MockPlugin } from '../util/plugins';
+
 const iopipe = require('./iopipe');
 
 describe('Using rc file iopipe configuration', () => {
@@ -8,17 +10,28 @@ describe('Using rc file iopipe configuration', () => {
   });
 
   it('Has configuration', done => {
-    iopipe({ networkTimeout: 345 })((event, context) => {
+    let inspectableInvocation;
+    iopipe({
+      networkTimeout: 345,
+      plugins: [
+        inv => {
+          inspectableInvocation = inv;
+          return new MockPlugin(inv);
+        }
+      ]
+    })((event, context) => {
       try {
-        const { clientId, networkTimeout, plugins } = context.iopipe.config;
+        const { clientId, networkTimeout } = context.iopipe.config;
+        const { plugins } = inspectableInvocation;
 
         expect(clientId).toBe('rc_file_config_token_wow');
 
         expect(networkTimeout).toBe(345);
 
-        expect(plugins.length).toBe(1);
-
-        expect(_.isFunction(plugins[0])).toBe(true);
+        expect(_.map(plugins, 'meta.name')).toEqual([
+          'mock-plugin',
+          '@iopipe/trace'
+        ]);
 
         expect(_.isFunction(context.iopipe.mark.start)).toBe(true);
         // the config should be "empty"...

--- a/testProjects/util/plugins.js
+++ b/testProjects/util/plugins.js
@@ -1,0 +1,22 @@
+export class MockPlugin {
+  constructor() {
+    return this;
+  }
+  get meta() {
+    return {
+      name: 'mock-plugin'
+    };
+  }
+}
+
+export class MockTracePlugin {
+  constructor() {
+    return this;
+  }
+  get meta() {
+    return {
+      name: '@iopipe/trace',
+      version: 'mocked-trace'
+    };
+  }
+}

--- a/util/testProjects.js
+++ b/util/testProjects.js
@@ -1,19 +1,30 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const _ = require('lodash');
 const spawn = require('cross-spawn');
+const argv = require('yargs').argv;
 
 const testDirFiles = fs.readdirSync(path.join(__dirname, '../testProjects'));
-const folders = _.reject(testDirFiles, s => s.match(/^\./));
+const folders = _.chain(testDirFiles)
+  .reject(s => s.match(/^\./))
+  .reject(s => s === 'util')
+  .filter(file => {
+    const toInclude = argv.folders || argv.projects;
+    if (toInclude) {
+      return _.includes(toInclude, file);
+    }
+    return true;
+  })
+  .value();
 
 folders.forEach(folder => {
-  spawn.sync('npm', ['install', '--prefix', `testProjects/${folder}`], {
+  spawn.sync('yarn', ['install', '--cwd', `testProjects/${folder}`], {
     stdio: 'inherit'
   });
 
   fs.copyFileSync('dist/iopipe.js', `testProjects/${folder}/iopipe.js`);
 
-  spawn.sync('npm', ['test', '--prefix', `testProjects/${folder}`], {
+  spawn.sync('yarn', ['--cwd', `testProjects/${folder}`, 'test'], {
     stdio: 'inherit'
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5927,6 +5927,12 @@ yargs-parser@^8.1.0:
   dependencies:
     camelcase "^4.1.0"
 
+yargs-parser@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-9.0.2.tgz#9ccf6a43460fe4ed40a9bb68f48d43b8a68cc077"
+  dependencies:
+    camelcase "^4.1.0"
+
 yargs@^10.0.3:
   version "10.1.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-10.1.2.tgz#454d074c2b16a51a43e2fb7807e4f9de69ccb5c5"
@@ -5943,6 +5949,23 @@ yargs@^10.0.3:
     which-module "^2.0.0"
     y18n "^3.2.1"
     yargs-parser "^8.1.0"
+
+yargs@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-11.0.0.tgz#c052931006c5eee74610e5fc0354bedfd08a201b"
+  dependencies:
+    cliui "^4.0.0"
+    decamelize "^1.1.1"
+    find-up "^2.1.0"
+    get-caller-file "^1.0.1"
+    os-locale "^2.0.0"
+    require-directory "^2.1.1"
+    require-main-filename "^1.0.1"
+    set-blocking "^2.0.0"
+    string-width "^2.0.0"
+    which-module "^2.0.0"
+    y18n "^3.2.1"
+    yargs-parser "^9.0.2"
 
 yargs@^6.0.0:
   version "6.6.0"


### PR DESCRIPTION
- Fixes #225 
- Adds eslint to testProjects
- Centralizes testProject utilities
- Better tests on the plugins with `inspectableInvocation`