### PR TITLE
chore(tests): Use results of testProjects runs for process.exit

### DIFF
--- a/util/testProjects.js
+++ b/util/testProjects.js
@@ -17,14 +17,25 @@ const folders = _.chain(testDirFiles)
   })
   .value();
 
+const results = [];
+function resultPush({ status }) {
+  results.push(status);
+}
+
 folders.forEach(folder => {
-  spawn.sync('yarn', ['install', '--cwd', `testProjects/${folder}`], {
-    stdio: 'inherit'
-  });
+  resultPush(
+    spawn.sync('yarn', ['install', '--cwd', `testProjects/${folder}`], {
+      stdio: 'inherit'
+    })
+  );
 
   fs.copyFileSync('dist/iopipe.js', `testProjects/${folder}/iopipe.js`);
 
-  spawn.sync('yarn', ['--cwd', `testProjects/${folder}`, 'test'], {
-    stdio: 'inherit'
-  });
+  resultPush(
+    spawn.sync('yarn', ['--cwd', `testProjects/${folder}`, 'test'], {
+      stdio: 'inherit'
+    })
+  );
 });
+
+process.exit(_.max(results));


### PR DESCRIPTION
If test results are not taken into account for process.exit, CI will always pass even if tests fail.