### PR TITLE
chore(tests): reset env vars for every test

### DIFF
--- a/src/collector.test.js
+++ b/src/collector.test.js
@@ -1,21 +1,22 @@
 import collector from './collector';
 const { getHostname, getCollectorPath } = collector;
 
+import { resetEnv } from '../util/testUtils';
+
 describe('configuring collector hostname', () => {
   beforeEach(() => {
-    // clear region for testing
-    process.env.AWS_REGION = '';
+    resetEnv();
   });
 
-  it('returns a base hostname if nothing else', () => {
+  test('returns a base hostname if nothing else', () => {
     expect(getHostname()).toBe('metrics-api.iopipe.com');
   });
 
-  it('returns a configured url if provided in config object', () => {
+  test('returns a configured url if provided in config object', () => {
     expect(getHostname('http://myurl')).toBe('myurl');
   });
 
-  it('switches based on the region set in env vars', () => {
+  test('switches based on the region set in env vars', () => {
     process.env.AWS_REGION = 'ap-southeast-2';
     let apSoutheast2Collector = getHostname('', {});
     process.env.AWS_REGION = 'eu-west-1';
@@ -34,7 +35,7 @@ describe('configuring collector hostname', () => {
     expect(west2Collector).toBe('metrics-api.us-west-2.iopipe.com');
   });
 
-  it('defaults if an uncovered region or malformed', () => {
+  test('defaults if an uncovered region or malformed', () => {
     process.env.AWS_REGION = 'eu-west-2';
     let euWest2Collector = getHostname('', {});
 
@@ -51,7 +52,7 @@ describe('configuring collector hostname', () => {
 });
 
 describe('configuring path', () => {
-  it('adds query strings to the path', () => {
+  test('adds query strings to the path', () => {
     expect(getCollectorPath('http://myurl?foo')).toBe('/v0/event?foo');
   });
 });

--- a/src/config/index.test.js
+++ b/src/config/index.test.js
@@ -1,4 +1,5 @@
 import setConfig from './index';
+import { resetEnv } from '../../util/testUtils';
 
 jest.mock('./util');
 jest.mock('@iopipe/config', () => {
@@ -9,16 +10,12 @@ jest.mock('@iopipe/config', () => {
 
 import { setConfigPath } from './util';
 
-describe('setting up config object', () => {
-  beforeEach(() => {
-    delete process.env.AWS_REGION;
-    delete process.env.IOPIPE_CLIENTID;
-    delete process.env.IOPIPE_ENABLED;
-    delete process.env.IOPIPE_TIMEOUT_WINDOW;
-    delete process.env.IOPIPE_TOKEN;
-  });
+beforeEach(() => {
+  resetEnv();
+});
 
-  it('can accept 0 arguments and returns default config', () => {
+describe('setting up config object', () => {
+  test('can accept 0 arguments and returns default config', () => {
     const config = setConfig();
 
     expect(config.clientId).toEqual('');
@@ -40,13 +37,13 @@ describe('setting up config object', () => {
     expect(config.timeoutWindow).toEqual(150);
   });
 
-  it('configures a client id', () => {
+  test('configures a client id', () => {
     expect(setConfig({ token: 'foo' }).clientId).toEqual('foo');
 
     expect(setConfig({ clientId: 'bar' }).clientId).toEqual('bar');
   });
 
-  it('sets preferences for order of client id config', () => {
+  test('sets preferences for order of client id config', () => {
     // takes token over clientId
     expect(setConfig({ clientId: 'bar', token: 'foo' }).clientId).toEqual(
       'foo'
@@ -62,7 +59,7 @@ describe('setting up config object', () => {
     expect(setConfig().clientId).toEqual('baz');
   });
 
-  it('sets timeout windows', () => {
+  test('sets timeout windows', () => {
     expect(setConfig({ timeoutWindow: 0 }).timeoutWindow).toEqual(0);
 
     process.env.IOPIPE_TIMEOUT_WINDOW = 100;
@@ -72,7 +69,7 @@ describe('setting up config object', () => {
     expect(setConfig({ timeoutWindow: 0 }).timeoutWindow).toEqual(0);
   });
 
-  it('can be configured via config file', () => {
+  test('can be configured via config file', () => {
     setConfigPath('./package');
 
     const config = setConfig();
@@ -98,11 +95,11 @@ describe('setting up config object', () => {
     expect(setConfig().clientId).toBe('barbaz');
   });
 
-  it('can disable agent', () => {
+  test('can disable agent', () => {
     expect(setConfig({ enabled: false }).enabled).toBe(false);
   });
 
-  it('can disable agent via environment variable', () => {
+  test('can disable agent via environment variable', () => {
     process.env.IOPIPE_ENABLED = '0';
 
     expect(setConfig().enabled).toBe(false);
@@ -112,7 +109,7 @@ describe('setting up config object', () => {
     expect(setConfig().enabled).toBe(false);
   });
 
-  it('should only be disabled explicitly', () => {
+  test('should only be disabled explicitly', () => {
     process.env.IOPIPE_ENABLED = 'xyz';
 
     expect(setConfig().enabled).toBe(true);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import IOpipe from '../dist/iopipe.js';
 import mockContext from 'aws-lambda-mock-context';
-// default region for testing
-process.env.AWS_REGION = 'us-east-1';
+
+import { resetEnv } from '../util/testUtils';
 
 function defaultCatch(err) {
   console.error(err);
@@ -64,19 +64,23 @@ function sendToRegionTest(region = 'us-east-1', done) {
   });
 }
 
+beforeEach(() => {
+  resetEnv();
+});
+
 describe('metrics agent', () => {
-  it('should return a function', () => {
+  test('should return a function', () => {
     const agent = createAgent();
     expect(typeof agent).toEqual('function');
   });
 
-  it('should successfully getRemainingTimeInMillis from aws context', () => {
+  test('should successfully getRemainingTimeInMillis from aws context', () => {
     runWrappedFunction().then(obj => {
       expect(typeof obj.ctx.getRemainingTimeInMillis).toBe('function');
     });
   });
 
-  it('runs the user function and returns the original value', done => {
+  test('runs the user function and returns the original value', done => {
     const iopipe = createAgent();
     const wrappedFunction = iopipe((event, ctx) => {
       ctx.succeed('Decorate');
@@ -91,7 +95,7 @@ describe('metrics agent', () => {
       .catch(defaultCatch);
   });
 
-  it('allows per-setup configuration', done => {
+  test('allows per-setup configuration', done => {
     const completed = {
       f1: false,
       f2: false
@@ -131,7 +135,7 @@ describe('metrics agent', () => {
       .catch(defaultCatch);
   });
 
-  it('allows .decorate API', done => {
+  test('allows .decorate API', done => {
     const iopipe = createAgent();
     const wrappedFunction = iopipe.decorate((event, ctx) => {
       ctx.succeed('Decorate');
@@ -145,7 +149,7 @@ describe('metrics agent', () => {
       .catch(defaultCatch);
   });
 
-  it('Returns a value from context.succeed', done => {
+  test('Returns a value from context.succeed', done => {
     const iopipe = createAgent({ debug: true });
     const wrappedFunction = iopipe((event, ctx) => {
       ctx.succeed('my-val');
@@ -171,7 +175,7 @@ describe('metrics agent', () => {
     }, 1000);
   });
 
-  it('Returns a value from callback', done => {
+  test('Returns a value from callback', done => {
     const iopipe = createAgent({ debug: true });
     const wrappedFunction = iopipe((event, ctx, cb) => {
       cb(null, 'my-val');
@@ -197,7 +201,7 @@ describe('metrics agent', () => {
     }, 1000);
   });
 
-  it('has a proper context object', done => {
+  test('has a proper context object', done => {
     expect.assertions(6);
     const iopipe = createAgent();
     const wrappedFunction = iopipe.decorate((event, ctx) => {
@@ -223,7 +227,7 @@ describe('metrics agent', () => {
       .catch(defaultCatch);
   });
 
-  it('will return unwrapped function if token unset', () => {
+  test('will return unwrapped function if token unset', () => {
     const fn = (event, context) => {
       context.succeed('Success');
     };
@@ -233,7 +237,7 @@ describe('metrics agent', () => {
     expect(agent(fn)).toBe(fn);
   });
 
-  it('will return unwrapped function if agent disabled', () => {
+  test('will return unwrapped function if agent disabled', () => {
     const fn = (event, context) => {
       context.succeed('Success');
     };
@@ -245,14 +249,14 @@ describe('metrics agent', () => {
 });
 
 describe('smoke test', () => {
-  it('will run when installed on a successful function', done => {
+  test('will run when installed on a successful function', done => {
     runWrappedFunction().then(obj => {
       expect(obj.response).toBeTruthy();
       done();
     });
   });
 
-  it('will run when installed on a failing function', done => {
+  test('will run when installed on a failing function', done => {
     const fn = (event, context) => {
       context.fail('Whoops!');
     };
@@ -265,7 +269,7 @@ describe('smoke test', () => {
   });
 
   describe('functions using callbacks', () => {
-    it('will run when installed on a successful function using callbacks', done => {
+    test('will run when installed on a successful function using callbacks', done => {
       const fn = (event, ctx, cb) => {
         cb(null, 'Success!');
       };
@@ -285,12 +289,12 @@ describe('smoke test', () => {
       'us-west-1',
       'us-west-2'
     ].forEach(region => {
-      it(`sends to ${region}`, done => {
+      test(`sends to ${region}`, done => {
         sendToRegionTest(region, done);
       });
     });
 
-    it('sends to custom URLs (staging)', done => {
+    test('sends to custom URLs (staging)', done => {
       runWrappedFunction(
         undefined,
         undefined,

--- a/src/mockSystem.test.js
+++ b/src/mockSystem.test.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import system from './mockSystem';
 
 describe('mock system functions', () => {
-  it('promisifies system data', () => {
+  test('promisifies system data', () => {
     let stat = system.readstat();
     let status = system.readstatus();
     let bootId = system.readbootid();
@@ -11,7 +11,7 @@ describe('mock system functions', () => {
     expect(Promise.resolve(bootId)).toEqual(stat);
   });
 
-  it('gives simple 0s for readstat', done => {
+  test('gives simple 0s for readstat', done => {
     expect.assertions(5);
     system.readstat().then(data => {
       const { utime, stime, cutime, cstime, rss } = data;

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -3,14 +3,20 @@ import flatten from 'flat';
 import Report from './report';
 import context from 'aws-lambda-mock-context';
 import MockPlugin from './plugins/mock';
+import { resetEnv } from '../util/testUtils';
+
 const schema = require('./schema.json');
 
 const config = {
   clientId: 'foo'
 };
 
+beforeEach(() => {
+  resetEnv();
+});
+
 describe('Report creation', () => {
-  it('creates a new report object', () => {
+  test('creates a new report object', () => {
     expect(
       typeof new Report({
         config,
@@ -19,11 +25,11 @@ describe('Report creation', () => {
     ).toBe('object');
   });
 
-  it('can take no arguments', () => {
+  test('can take no arguments', () => {
     expect(typeof new Report()).toBe('object');
   });
 
-  it('creates a report that matches the schema', done => {
+  test('creates a report that matches the schema', done => {
     const r = new Report({
       metrics: [{ name: 'foo-metric', s: 'wow-string', n: 99 }]
     });
@@ -64,7 +70,7 @@ describe('Report creation', () => {
     });
   });
 
-  it('keeps custom metrics references', () => {
+  test('keeps custom metrics references', () => {
     let myMetrics = [];
     const r = new Report({ config, context: context(), metrics: myMetrics });
     myMetrics.push({ n: 1, name: 'a_value' });
@@ -72,7 +78,7 @@ describe('Report creation', () => {
     expect(r.report.custom_metrics.length).toBe(1);
   });
 
-  it('tracks plugins in use', () => {
+  test('tracks plugins in use', () => {
     const plugin = MockPlugin();
 
     const r = new Report({ plugins: [plugin()] });
@@ -88,7 +94,7 @@ describe('Report creation', () => {
     );
   });
 
-  it('patches the ARN if SAM local is detected', () => {
+  test('patches the ARN if SAM local is detected', () => {
     process.env.AWS_SAM_LOCAL = true;
     const localReport = new Report({ config, context: context() });
     expect(localReport.report.aws.invokedFunctionArn).toBe(

--- a/testProjects/catchTypeError/handler.test.js
+++ b/testProjects/catchTypeError/handler.test.js
@@ -1,14 +1,16 @@
 import _ from 'lodash';
 import delay from 'delay';
 
+import { resetEnv } from '../../util/testUtils';
+
 const iopipe = require('./iopipe');
 
-describe('Catch typeError by wrapping require block', () => {
-  beforeEach(() => {
-    delete process.env.IOPIPE_TOKEN;
-  });
+beforeEach(() => {
+  resetEnv();
+});
 
-  it('Has configuration', async () => {
+describe('Catch typeError by wrapping require block', () => {
+  test('Has configuration', async () => {
     let inspectableInvocation;
     const result = await new Promise(resolve => {
       return iopipe({

--- a/testProjects/extendConfig/handler.test.js
+++ b/testProjects/extendConfig/handler.test.js
@@ -1,15 +1,16 @@
 import _ from 'lodash';
 
 import { MockPlugin } from '../util/plugins';
+import { resetEnv } from '../../util/testUtils';
 
 const iopipe = require('./iopipe');
 
-describe('Using extend iopipe configuration', () => {
-  beforeEach(() => {
-    delete process.env.IOPIPE_TOKEN;
-  });
+beforeEach(() => {
+  resetEnv();
+});
 
-  it('Has configuration', done => {
+describe('Using extend iopipe configuration', () => {
+  test('Has configuration', done => {
     let inspectableInvocation;
     iopipe({
       extends: '@iopipe/config',

--- a/testProjects/metaWithExtraPlugins/handler.test.js
+++ b/testProjects/metaWithExtraPlugins/handler.test.js
@@ -1,15 +1,16 @@
 import _ from 'lodash';
 
 import { MockPlugin, MockTracePlugin } from '../util/plugins';
+import { resetEnv } from '../../util/testUtils';
 
 const iopipe = require('./iopipe');
 
-describe('Meta with extra plugin, no deduping', () => {
-  beforeEach(() => {
-    delete process.env.IOPIPE_TOKEN;
-  });
+beforeEach(() => {
+  resetEnv();
+});
 
-  it('Has configuration', done => {
+describe('Meta with extra plugin, no deduping', () => {
+  test('Has configuration', done => {
     let inspectableInvocation;
     iopipe({
       clientId: 'foobar',
@@ -45,11 +46,8 @@ describe('Meta with extra plugin, no deduping', () => {
 
 describe('Meta with extra plugin, dedupes trace plugin', () => {
   /* When a consumer provides their own plugins, the plugins should be deduped via the meta.name string. If a consumer provides a duplicate with the same meta.name, their plugin should be used instead of the default. */
-  beforeEach(() => {
-    delete process.env.IOPIPE_TOKEN;
-  });
 
-  it('Has configuration', done => {
+  test('Has configuration', done => {
     let inspectableInvocation;
     iopipe({
       clientId: 'foobar',

--- a/testProjects/packageJsonConfig/handler.test.js
+++ b/testProjects/packageJsonConfig/handler.test.js
@@ -1,15 +1,16 @@
 import _ from 'lodash';
 
 import { MockPlugin } from '../util/plugins';
+import { resetEnv } from '../../util/testUtils';
 
 const iopipe = require('./iopipe');
 
-describe('Using package.json iopipe configuration', () => {
-  beforeEach(() => {
-    delete process.env.IOPIPE_TOKEN;
-  });
+beforeEach(() => {
+  resetEnv();
+});
 
-  it('Has configuration', done => {
+describe('Using package.json iopipe configuration', () => {
+  test('Has configuration', done => {
     let inspectableInvocation;
     iopipe({
       networkTimeout: 345,

--- a/testProjects/rcFileConfig/handler.test.js
+++ b/testProjects/rcFileConfig/handler.test.js
@@ -1,15 +1,16 @@
 import _ from 'lodash';
 
 import { MockPlugin } from '../util/plugins';
+import { resetEnv } from '../../util/testUtils';
 
 const iopipe = require('./iopipe');
 
-describe('Using rc file iopipe configuration', () => {
-  beforeEach(() => {
-    delete process.env.IOPIPE_TOKEN;
-  });
+beforeEach(() => {
+  resetEnv();
+});
 
-  it('Has configuration', done => {
+describe('Using rc file iopipe configuration', () => {
+  test('Has configuration', done => {
     let inspectableInvocation;
     iopipe({
       networkTimeout: 345,

--- a/util/testProjects.js
+++ b/util/testProjects.js
@@ -23,6 +23,7 @@ function resultPush({ status }) {
 }
 
 folders.forEach(folder => {
+  console.log(`Running tests for ${folder}...`);
   resultPush(
     spawn.sync('yarn', ['install', '--cwd', `testProjects/${folder}`], {
       stdio: 'inherit'
@@ -36,6 +37,7 @@ folders.forEach(folder => {
       stdio: 'inherit'
     })
   );
+  console.log(`Finished tests for ${folder}.`);
 });
 
 process.exit(_.max(results));

--- a/util/testUtils.js
+++ b/util/testUtils.js
@@ -1,0 +1,17 @@
+const supportedEnvVars = [
+  'IOPIPE_TOKEN',
+  'IOPIPE_DEBUG',
+  'IOPIPE_ENABLED',
+  'IOPIPE_INSTALL_METHOD',
+  'IOPIPE_CLIENTID',
+  'IOPIPE_NETWORK_TIMEOUT',
+  'IOPIPE_TIMEOUT_WINDOW',
+  'AWS_REGION',
+  'AWS_SAM_LOCAL'
+];
+
+function resetEnv() {
+  supportedEnvVars.forEach(str => delete process.env[str]);
+}
+
+export { resetEnv, supportedEnvVars };


### PR DESCRIPTION
- Make tests as repeatable as possbile across environments.
- Use `test` instead of `it` as it's "official" to the jest api (but has no functional difference)
- Log the testProject being run before + after tests
- Fixes #236 