### PR TITLE
feat(labels): Add .metric and .label syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,29 @@ IOpipe Analytics & Distributed Tracing Agent
 
 This package provides analytics and distributed tracing for event-driven applications running on AWS Lambda.
 
-# Installation & usage
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Custom Metrics](#custom-metrics)
+  - [Tags](#tags)
+- [Configuration](#configuration)
+  - [Methods](#methods)
+  - [Options](#options)
 
-Install by requiring this module, passing it an object with your project token ([register for access](https://www.iopipe.com)), and it will automatically monitor and collect metrics from your applications running on AWS Lambda.
+# Installation
+
+Install using your package manager of choice,
+
+`npm install @iopipe/core`
+
+or
+
+`yarn add @iopipe/core`
 
 If you are using the Serverless Framework to deploy your lambdas, check out our [serverless plugin](https://github.com/iopipe/serverless-plugin-iopipe).
+
+# Usage
+
+Configure the library with your project token ([register for access](https://www.iopipe.com)), and it will automatically monitor and collect metrics from your applications running on AWS Lambda.
 
 Example:
 
@@ -20,6 +38,43 @@ const iopipeLib = require('@iopipe/core');
 const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
 
 exports.handler = iopipe((event, context) => {
+  context.succeed('This is my serverless function!');
+});
+```
+
+## Custom metrics
+
+You may add custom metrics to an invocation using `context.iopipe.metric` to add
+either string or numerical values. Keys have a maximum length of 256 characters, and string values are limited
+to 1024.
+
+Example:
+
+```js
+const iopipeLib = require('@iopipe/core');
+
+const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
+
+exports.handler = iopipe((event, context) => {
+  context.iopipe.metric('key', 'some-value');
+  context.iopipe.metric('another-key', 42);
+  context.succeed('This is my serverless function!');
+});
+```
+
+## Tagging
+
+You can tag invocations using `context.iopipe.tag` to tag an invocation with a string value, with a limit of 256 characters.
+
+Example:
+
+```js
+const iopipeLib = require('@iopipe/core');
+
+const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
+
+exports.handler = iopipe((event, context) => {
+  context.iopipe.tag('something-important-happened');
   context.succeed('This is my serverless function!');
 });
 ```
@@ -41,7 +96,7 @@ You can configure your iopipe setup through one or more different methods - that
 
 #### `token` (string: required)
 
-If not supplied, the environment variable `$IOPIPE_TOKEN` will be used if present. [Find your project token](https://dashboard.iopipe.com/install)
+If not supplied, the environment variable `$IOPIPE_TOKEN` will be used if present. [Find your project token](https://dashboard.iopipe.com/install).
 
 #### `debug` (bool: optional = false)
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package provides analytics and distributed tracing for event-driven applica
 - [Installation](#installation)
 - [Usage](#usage)
   - [Custom Metrics](#custom-metrics)
-  - [Tags](#tags)
+  - [Labels](#labels)
 - [Configuration](#configuration)
   - [Methods](#methods)
   - [Options](#options)
@@ -62,9 +62,9 @@ exports.handler = iopipe((event, context) => {
 });
 ```
 
-## Tagging
+## Labels
 
-You can tag invocations using `context.iopipe.tag` to tag an invocation with a string value, with a limit of 256 characters.
+You can label invocations using `context.iopipe.label` to label an invocation with a string value, with a limit of 128 characters.
 
 Example:
 
@@ -74,7 +74,7 @@ const iopipeLib = require('@iopipe/core');
 const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
 
 exports.handler = iopipe((event, context) => {
-  context.iopipe.tag('something-important-happened');
+  context.iopipe.label('something-important-happened');
   context.succeed('This is my serverless function!');
 });
 ```

--- a/src/__snapshots__/class.test.js.snap
+++ b/src/__snapshots__/class.test.js.snap
@@ -30,7 +30,7 @@ Array [
   Object {
     "n": undefined,
     "name": "metric-6",
-    "s": undefined,
+    "s": "undefined",
   },
   Object {
     "n": undefined,
@@ -103,5 +103,59 @@ Array [
       "s": "true",
     },
   ],
+]
+`;
+
+exports[`ctx.iopipe.metric adds metrics to the custom_metrics array 1`] = `
+Array [
+  Object {
+    "n": undefined,
+    "name": "metric-1",
+    "s": "foo",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-2",
+    "s": "true",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-3",
+    "s": "{\\"ding\\":\\"dong\\"}",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-4",
+    "s": "[\\"whoa\\"]",
+  },
+  Object {
+    "n": 100,
+    "name": "metric-5",
+    "s": undefined,
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-6",
+    "s": "NaN",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-7",
+    "s": "undefined",
+  },
+]
+`;
+
+exports[`ctx.iopipe.tag adds tags to the custom_metrics array 1`] = `
+Array [
+  Object {
+    "name": "tag-1",
+  },
+  Object {
+    "name": "2",
+  },
+  Object {
+    "name": "{\\"foo\\":\\"bar\\"}",
+  },
 ]
 `;

--- a/src/__snapshots__/class.test.js.snap
+++ b/src/__snapshots__/class.test.js.snap
@@ -106,6 +106,13 @@ Array [
 ]
 `;
 
+exports[`ctx.iopipe.label adds labels to the labels array 1`] = `
+Array [
+  "label-1",
+  "label-2",
+]
+`;
+
 exports[`ctx.iopipe.metric adds metrics to the custom_metrics array 1`] = `
 Array [
   Object {
@@ -142,20 +149,6 @@ Array [
     "n": undefined,
     "name": "metric-7",
     "s": "undefined",
-  },
-]
-`;
-
-exports[`ctx.iopipe.tag adds tags to the custom_metrics array 1`] = `
-Array [
-  Object {
-    "name": "tag-1",
-  },
-  Object {
-    "name": "2",
-  },
-  Object {
-    "name": "{\\"foo\\":\\"bar\\"}",
   },
 ]
 `;

--- a/src/class.test.js
+++ b/src/class.test.js
@@ -189,6 +189,75 @@ test('Allows ctx.iopipe.log and iopipe.log functionality', async () => {
   }
 });
 
+test('ctx.iopipe.metric adds metrics to the custom_metrics array', async () => {
+  expect.assertions(4);
+  try {
+    const iopipe = createAgent({});
+    const wrappedFunction = iopipe(function Wrapper(event, ctx) {
+      ctx.iopipe.metric('metric-1', 'foo');
+      ctx.iopipe.metric('metric-2', true);
+      ctx.iopipe.metric('metric-3', { ding: 'dong' });
+      ctx.iopipe.metric('metric-4', ['whoa']);
+      ctx.iopipe.metric('metric-5', 100);
+      // NaN is saved as string
+      ctx.iopipe.metric('metric-6', Number('foo'));
+      ctx.iopipe.metric('metric-7');
+      // This is too long to be added
+      ctx.iopipe.metric(
+        new Array(258).join('a'),
+        'value not saved because key too long'
+      );
+      ctx.succeed('all done');
+    });
+
+    const context = mockContext({ functionName: 'metric-test' });
+    wrappedFunction({}, context);
+    const val = await context.Promise;
+    expect(val).toEqual('all done');
+
+    const metrics = _.chain(reports)
+      .find(obj => obj.aws.functionName === 'metric-test')
+      .get('custom_metrics')
+      .value();
+    expect(_.isArray(metrics)).toBe(true);
+    expect(metrics.length).toBe(7);
+    expect(metrics).toMatchSnapshot();
+  } catch (err) {
+    throw err;
+  }
+});
+
+test('ctx.iopipe.tag adds tags to the custom_metrics array', async () => {
+  expect.assertions(4);
+  try {
+    const iopipe = createAgent({});
+    const wrappedFunction = iopipe(function Wrapper(event, ctx) {
+      ctx.iopipe.tag('tag-1');
+      // Tags are stringified
+      ctx.iopipe.tag(2);
+      ctx.iopipe.tag({ foo: 'bar' });
+      // This tag is too long to be added
+      ctx.iopipe.tag(new Array(258).join('a'));
+      ctx.succeed('all done');
+    });
+
+    const context = mockContext({ functionName: 'tag-test' });
+    wrappedFunction({}, context);
+    const val = await context.Promise;
+    expect(val).toEqual('all done');
+
+    const metrics = _.chain(reports)
+      .find(obj => obj.aws.functionName === 'tag-test')
+      .get('custom_metrics')
+      .value();
+    expect(_.isArray(metrics)).toBe(true);
+    expect(metrics.length).toBe(3);
+    expect(metrics).toMatchSnapshot();
+  } catch (err) {
+    throw err;
+  }
+});
+
 test('Does not have context.iopipe.log collisions', async () => {
   try {
     const iopipe = createAgent({

--- a/src/class.test.js
+++ b/src/class.test.js
@@ -220,7 +220,7 @@ test('ctx.iopipe.metric adds metrics to the custom_metrics array', async () => {
       .get('custom_metrics')
       .value();
     expect(_.isArray(metrics)).toBe(true);
-    expect(metrics.length).toBe(7);
+    expect(metrics).toHaveLength(7);
     expect(metrics).toMatchSnapshot();
   } catch (err) {
     throw err;
@@ -251,7 +251,7 @@ test('ctx.iopipe.tag adds tags to the custom_metrics array', async () => {
       .get('custom_metrics')
       .value();
     expect(_.isArray(metrics)).toBe(true);
-    expect(metrics.length).toBe(3);
+    expect(metrics).toHaveLength(3);
     expect(metrics).toMatchSnapshot();
   } catch (err) {
     throw err;

--- a/src/class.test.js
+++ b/src/class.test.js
@@ -204,7 +204,7 @@ test('ctx.iopipe.metric adds metrics to the custom_metrics array', async () => {
       ctx.iopipe.metric('metric-7');
       // This is too long to be added
       ctx.iopipe.metric(
-        new Array(258).join('a'),
+        new Array(130).join('a'),
         'value not saved because key too long'
       );
       ctx.succeed('all done');
@@ -237,7 +237,7 @@ test('ctx.iopipe.tag adds tags to the custom_metrics array', async () => {
       ctx.iopipe.tag(2);
       ctx.iopipe.tag({ foo: 'bar' });
       // This tag is too long to be added
-      ctx.iopipe.tag(new Array(258).join('a'));
+      ctx.iopipe.tag(new Array(130).join('a'));
       ctx.succeed('all done');
     });
 

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ class IOpipeWrapperClass {
     this.startTimestamp = Date.now();
     this.config = config;
     this.metrics = [];
+    this.labels = new Set();
     this.originalIdentity = originalIdentity;
     this.event = originalEvent;
     this.originalContext = originalContext;
@@ -84,9 +85,9 @@ class IOpipeWrapperClass {
       fail: this.fail.bind(this),
       done: this.done.bind(this),
       iopipe: {
+        label: this.label.bind(this),
         log: this.log.bind(this),
         metric: this.metric.bind(this),
-        tag: this.tag.bind(this),
         version: VERSION,
         config: this.config
       }
@@ -123,8 +124,7 @@ class IOpipeWrapperClass {
       delete this.originalContext[reset ? `original_${method}` : method];
     });
   }
-  debugLog(message, level='warn') {
-    console.log(this.config)
+  debugLog(message, level = 'warn') {
     if (this.config.debug) {
       console[level](message);
     }
@@ -222,20 +222,21 @@ class IOpipeWrapperClass {
       s: stringValue
     });
   }
-  tag(nameInput) {
+  label(name) {
     if (typeof name !== 'string') {
-      this.debugLog(`Tag name ${name} is not a string and will not be saved`);
+      this.debugLog(`Label ${name} is not a string and will not be saved`);
+      return;
     }
-    const name = convertToString(nameInput);
     if (name.length > 128) {
       this.debugLog(
-        `Tag with name ${name} is longer than allowed length of 128, tag will not be saved`
+        `Label with name ${name} is longer than allowed length of 128, label will not be saved`
       );
       return;
     }
-    this.metrics.push({ name });
+    this.labels.add(name);
+    console.log(this.labels);
   }
-  // DEPRECATED: This method is deprecated in favor of .metric and .tag
+  // DEPRECATED: This method is deprecated in favor of .metric and .label
   log(name, value) {
     this.debugLog(
       'context.iopipe.log is deprecated and will be removed in a future version, please use context.iopipe.metric'

--- a/src/index.js
+++ b/src/index.js
@@ -197,9 +197,8 @@ class IOpipeWrapperClass {
     });
   }
   metric(keyInput, valueInput) {
+    let numberValue, stringValue;
     const key = convertToString(keyInput);
-    var numberValue = undefined;
-    var stringValue = undefined;
     if (key.length > 256) {
       console.warn(
         `Metric with key name ${key} is longer than allowed length of 256, metric will not be saved`

--- a/src/index.js
+++ b/src/index.js
@@ -199,7 +199,7 @@ class IOpipeWrapperClass {
   metric(keyInput, valueInput) {
     let numberValue, stringValue;
     const key = convertToString(keyInput);
-    if (key.length > 256) {
+    if (key.length > 128) {
       console.warn(
         `Metric with key name ${key} is longer than allowed length of 256, metric will not be saved`
       );
@@ -218,7 +218,7 @@ class IOpipeWrapperClass {
   }
   tag(nameInput) {
     const name = convertToString(nameInput);
-    if (name.length > 256) {
+    if (name.length > 128) {
       console.warn(
         `Tag with name ${name} is longer than allowed length of 256, tag will not be saved`
       );

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,12 @@ class IOpipeWrapperClass {
       delete this.originalContext[reset ? `original_${method}` : method];
     });
   }
+  debugLog(message, level='warn') {
+    console.log(this.config)
+    if (this.config.debug) {
+      console[level](message);
+    }
+  }
   invoke() {
     this.runHook('pre:invoke');
     try {
@@ -200,12 +206,12 @@ class IOpipeWrapperClass {
     let numberValue, stringValue;
     const key = convertToString(keyInput);
     if (key.length > 128) {
-      console.warn(
-        `Metric with key name ${key} is longer than allowed length of 256, metric will not be saved`
+      this.debugLog(
+        `Metric with key name ${key} is longer than allowed length of 128, metric will not be saved`
       );
       return;
     }
-    if (typeof valueInput === 'number' && Number.isFinite(valueInput)) {
+    if (Number.isFinite(valueInput)) {
       numberValue = valueInput;
     } else {
       stringValue = convertToString(valueInput);
@@ -217,10 +223,13 @@ class IOpipeWrapperClass {
     });
   }
   tag(nameInput) {
+    if (typeof name !== 'string') {
+      this.debugLog(`Tag name ${name} is not a string and will not be saved`);
+    }
     const name = convertToString(nameInput);
     if (name.length > 128) {
-      console.warn(
-        `Tag with name ${name} is longer than allowed length of 256, tag will not be saved`
+      this.debugLog(
+        `Tag with name ${name} is longer than allowed length of 128, tag will not be saved`
       );
       return;
     }
@@ -228,7 +237,7 @@ class IOpipeWrapperClass {
   }
   // DEPRECATED: This method is deprecated in favor of .metric and .tag
   log(name, value) {
-    console.warn(
+    this.debugLog(
       'context.iopipe.log is deprecated and will be removed in a future version, please use context.iopipe.metric'
     );
     this.metric(name, value);

--- a/src/index.js
+++ b/src/index.js
@@ -234,7 +234,6 @@ class IOpipeWrapperClass {
       return;
     }
     this.labels.add(name);
-    console.log(this.labels);
   }
   // DEPRECATED: This method is deprecated in favor of .metric and .label
   log(name, value) {

--- a/src/report.js
+++ b/src/report.js
@@ -34,6 +34,7 @@ class Report {
       context = {},
       dnsPromise = Promise.resolve(),
       metrics = [],
+      labels = new Set(),
       plugins = [],
       startTime = process.hrtime(),
       startTimestamp = Date.now()
@@ -115,6 +116,7 @@ class Report {
       errors: {},
       coldstart: COLDSTART,
       custom_metrics: metrics,
+      labels,
       plugins: pluginMetas
     };
 
@@ -202,6 +204,9 @@ class Report {
     this.report.duration = Math.ceil(
       durationHrTime[0] * 1e9 + durationHrTime[1]
     );
+
+    // Convert labels from set to array
+    this.report.labels = Array.from(this.report.labels);
 
     if (config.debug) {
       log('IOPIPE-DEBUG: ', JSON.stringify(this.report));

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,6 @@
+export function convertToString(value) {
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,0 +1,9 @@
+import { convertToString } from './util';
+
+test('converts to string', () => {
+  expect(convertToString('Foo')).toBe('Foo');
+  expect(convertToString(undefined)).toBe('undefined');
+  expect(convertToString(NaN)).toBe('NaN');
+  expect(convertToString({ foo: 1 })).toBe('{"foo":1}');
+  expect(convertToString([1, 2])).toBe('[1,2]');
+});

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -6,4 +6,8 @@ test('converts to string', () => {
   expect(convertToString(NaN)).toBe('NaN');
   expect(convertToString({ foo: 1 })).toBe('{"foo":1}');
   expect(convertToString([1, 2])).toBe('[1,2]');
+  expect(convertToString(true)).toBe('true');
+  expect(convertToString(100)).toBe('100');
+  expect(convertToString(null)).toBe('null');
+  expect(convertToString(Symbol('foo'))).toBe('Symbol(foo)');
 });


### PR DESCRIPTION
- Adds .metric and .label syntax to support "labeling" invocations.
- Updates current .log method with deprecation notes.
- Adds docs for custom metrics and labels
- Updates README to include a table of contents for quick linking