### PR TITLE
feat(labels): Add .metric and .label syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,29 @@ IOpipe Analytics & Distributed Tracing Agent
 
 This package provides analytics and distributed tracing for event-driven applications running on AWS Lambda.
 
-# Installation & usage
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Custom Metrics](#custom-metrics)
+  - [Labels](#labels)
+- [Configuration](#configuration)
+  - [Methods](#methods)
+  - [Options](#options)
 
-Install by requiring this module, passing it an object with your project token ([register for access](https://www.iopipe.com)), and it will automatically monitor and collect metrics from your applications running on AWS Lambda.
+# Installation
+
+Install using your package manager of choice,
+
+`npm install @iopipe/core`
+
+or
+
+`yarn add @iopipe/core`
 
 If you are using the Serverless Framework to deploy your lambdas, check out our [serverless plugin](https://github.com/iopipe/serverless-plugin-iopipe).
+
+# Usage
+
+Configure the library with your project token ([register for access](https://www.iopipe.com)), and it will automatically monitor and collect metrics from your applications running on AWS Lambda.
 
 Example:
 
@@ -20,6 +38,43 @@ const iopipeLib = require('@iopipe/core');
 const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
 
 exports.handler = iopipe((event, context) => {
+  context.succeed('This is my serverless function!');
+});
+```
+
+## Custom metrics
+
+You may add custom metrics to an invocation using `context.iopipe.metric` to add
+either string or numerical values. Keys have a maximum length of 256 characters, and string values are limited
+to 1024.
+
+Example:
+
+```js
+const iopipeLib = require('@iopipe/core');
+
+const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
+
+exports.handler = iopipe((event, context) => {
+  context.iopipe.metric('key', 'some-value');
+  context.iopipe.metric('another-key', 42);
+  context.succeed('This is my serverless function!');
+});
+```
+
+## Labels
+
+You can label invocations using `context.iopipe.label` to label an invocation with a string value, with a limit of 128 characters.
+
+Example:
+
+```js
+const iopipeLib = require('@iopipe/core');
+
+const iopipe = iopipeLib({ token: 'PROJECT_TOKEN' });
+
+exports.handler = iopipe((event, context) => {
+  context.iopipe.label('something-important-happened');
   context.succeed('This is my serverless function!');
 });
 ```
@@ -41,7 +96,7 @@ You can configure your iopipe setup through one or more different methods - that
 
 #### `token` (string: required)
 
-If not supplied, the environment variable `$IOPIPE_TOKEN` will be used if present. [Find your project token](https://dashboard.iopipe.com/install)
+If not supplied, the environment variable `$IOPIPE_TOKEN` will be used if present. [Find your project token](https://dashboard.iopipe.com/install).
 
 #### `debug` (bool: optional = false)
 

--- a/acceptance/handler.js
+++ b/acceptance/handler.js
@@ -5,20 +5,40 @@ const iopipe = require('../dist/iopipe')({
 
 module.exports.callback = iopipe((event, context, callback) => {
   context.iopipe.log('custom_metric', 'A custom metric for callback');
+  context.iopipe.metric(
+    'custom_metric_with_metric',
+    'A custom metric for callback'
+  );
+  context.iopipe.label('callback');
   callback(null, 'callback');
 });
 
 module.exports.succeed = iopipe((event, context) => {
   context.iopipe.log('custom_metric', 'A custom metric for succeed');
+  context.iopipe.metric(
+    'custom_metric_with_metric',
+    'A custom metric for succeed'
+  );
+  context.iopipe.label('succeed');
   context.succeed('context.succeed');
 });
 
 module.exports.fail = iopipe((event, context) => {
   context.iopipe.log('custom_metric', 'A custom metric for fail');
+  context.iopipe.metric(
+    'custom_metric_with_metric',
+    'A custom metric for fail'
+  );
+  context.iopipe.label('fail');
   context.fail('context.fail');
 });
 
 module.exports.done = iopipe((event, context) => {
   context.iopipe.log('custom_metric', 'A custom metric for done');
+  context.iopipe.metric(
+    'custom_metric_with_metric',
+    'A custom metric for done'
+  );
+  context.iopipe.label('done');
   context.done(null, 'context.done');
 });

--- a/src/__snapshots__/class.test.js.snap
+++ b/src/__snapshots__/class.test.js.snap
@@ -30,7 +30,7 @@ Array [
   Object {
     "n": undefined,
     "name": "metric-6",
-    "s": undefined,
+    "s": "undefined",
   },
   Object {
     "n": undefined,
@@ -103,5 +103,52 @@ Array [
       "s": "true",
     },
   ],
+]
+`;
+
+exports[`ctx.iopipe.label adds labels to the labels array 1`] = `
+Array [
+  "label-1",
+  "label-2",
+]
+`;
+
+exports[`ctx.iopipe.metric adds metrics to the custom_metrics array 1`] = `
+Array [
+  Object {
+    "n": undefined,
+    "name": "metric-1",
+    "s": "foo",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-2",
+    "s": "true",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-3",
+    "s": "{\\"ding\\":\\"dong\\"}",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-4",
+    "s": "[\\"whoa\\"]",
+  },
+  Object {
+    "n": 100,
+    "name": "metric-5",
+    "s": undefined,
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-6",
+    "s": "NaN",
+  },
+  Object {
+    "n": undefined,
+    "name": "metric-7",
+    "s": "undefined",
+  },
 ]
 `;

--- a/src/report.js
+++ b/src/report.js
@@ -34,6 +34,7 @@ class Report {
       context = {},
       dnsPromise = Promise.resolve(),
       metrics = [],
+      labels = new Set(),
       plugins = [],
       startTime = process.hrtime(),
       startTimestamp = Date.now()
@@ -115,6 +116,7 @@ class Report {
       errors: {},
       coldstart: COLDSTART,
       custom_metrics: metrics,
+      labels,
       plugins: pluginMetas
     };
 
@@ -202,6 +204,9 @@ class Report {
     this.report.duration = Math.ceil(
       durationHrTime[0] * 1e9 + durationHrTime[1]
     );
+
+    // Convert labels from set to array
+    this.report.labels = Array.from(this.report.labels);
 
     if (config.debug) {
       log('IOPIPE-DEBUG: ', JSON.stringify(this.report));

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -57,7 +57,6 @@ describe('Report creation', () => {
         'environment.python.version',
         'errors.stackHash',
         'errors.count',
-        'labels',
         'performanceEntries.0.name',
         'performanceEntries.0.startTime',
         'performanceEntries.0.duration',

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,6 @@
+export function convertToString(value) {
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
+}

--- a/src/util.test.js
+++ b/src/util.test.js
@@ -1,0 +1,13 @@
+import { convertToString } from './util';
+
+test('converts to string', () => {
+  expect(convertToString('Foo')).toBe('Foo');
+  expect(convertToString(undefined)).toBe('undefined');
+  expect(convertToString(NaN)).toBe('NaN');
+  expect(convertToString({ foo: 1 })).toBe('{"foo":1}');
+  expect(convertToString([1, 2])).toBe('[1,2]');
+  expect(convertToString(true)).toBe('true');
+  expect(convertToString(100)).toBe('100');
+  expect(convertToString(null)).toBe('null');
+  expect(convertToString(Symbol('foo'))).toBe('Symbol(foo)');
+});


### PR DESCRIPTION
- Adds .metric and .label syntax to support "labeling" invocations.
- Updates current .log method with deprecation notes.
- Adds docs for custom metrics and labels
- Updates README to include a table of contents for quick linking