### PR TITLE
feat(getContext): expose getContext method to access invocation context

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "acceptanceLocalContextDone": "sls invoke local -f contextDone",
     "acceptanceLocal": "npm run acceptanceLocalCallback && npm run acceptanceLocalContextSuccess && npm run acceptanceLocalContextDone",
     "build": "npm run webpack",
+    "commit": "iopipe-scripts commit",
     "lint": "iopipe-scripts lint",
     "jest": "iopipe-scripts test",
     "prepare": "npm run build",

--- a/src/class.test.js
+++ b/src/class.test.js
@@ -382,11 +382,10 @@ test('When timing out, the lambda reports to iopipe, does not succeed, and repor
   }
 });
 
-test('Exposes getContext function', async () => {
+test('Exposes getContext function which is undefined before + after invocation, populated with current context during invocation', async () => {
   try {
     expect(_.isFunction(iopipeLib.getContext)).toBe(true);
-    // should equal the previous invocation context
-    expect(iopipeLib.getContext().functionName).toEqual('timeout-test');
+    expect(iopipeLib.getContext()).toBeUndefined();
     const iopipe = createAgent({ token: 'getContext' });
     const wrappedFunction = iopipe(function Wrapper(event, ctx) {
       ctx.succeed(200);
@@ -395,9 +394,10 @@ test('Exposes getContext function', async () => {
 
     const context = mockContext({ functionName: 'getContext' });
     wrappedFunction({}, context);
-    const val = await context.Promise;
-    expect(val).toEqual(200);
     expect(iopipeLib.getContext().functionName).toEqual('getContext');
+    const val = await context.Promise;
+    expect(iopipeLib.getContext()).toBeUndefined();
+    expect(val).toEqual(200);
     const metrics = _.chain(reports)
       .filter(r => r.client_id === 'getContext')
       .map('custom_metrics')

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,7 @@ class IOpipeWrapperClass {
       }
       this.report.send(async (...args) => {
         await this.runHook('post:report');
+        invocationContext = undefined;
         // reset the context back to its original state, otherwise aws gets unhappy
         this.setupContext(true);
         cb(...args);

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,8 @@ function setupTimeoutCapture(wrapperInstance) {
   }, endTime);
 }
 
+let invocationContext;
+
 //TODO: refactor to abide by max-params rule*/
 /*eslint-disable max-params*/
 
@@ -79,7 +81,7 @@ class IOpipeWrapperClass {
     this.setupContext();
 
     // assign modified methods and objects here
-    this.context = Object.assign(this.originalContext, {
+    this.context = invocationContext = Object.assign(this.originalContext, {
       // need to use .bind, otherwise, the this ref inside of each fn is NOT IOpipeWrapperClass
       succeed: this.succeed.bind(this),
       fail: this.fail.bind(this),
@@ -290,4 +292,8 @@ module.exports = options => {
   // Alias decorate to the wrapper function
   libFn.decorate = libFn;
   return libFn;
+};
+
+module.exports.getContext = function getContext() {
+  return invocationContext;
 };

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ class IOpipeWrapperClass {
     this.setupContext();
 
     // assign modified methods and objects here
-    this.context = invocationContext = Object.assign(this.originalContext, {
+    this.context = Object.assign(this.originalContext, {
       // need to use .bind, otherwise, the this ref inside of each fn is NOT IOpipeWrapperClass
       succeed: this.succeed.bind(this),
       fail: this.fail.bind(this),
@@ -94,6 +94,8 @@ class IOpipeWrapperClass {
         config: this.config
       }
     });
+
+    invocationContext = this.context;
 
     this.callback = (err, data) => {
       this.sendReport(err, () => {


### PR DESCRIPTION
`getContext` will allow consuming applications to use methods such as .metric and .label easier in a
multi-module app.

An eventual goal will be to allow consumers to easily use tracing and custom metrics throughout applications with an example of:

```js
import init, {metric, mark} from '@iopipe/iopipe';
```