### PR TITLE
fix(error handling): capture and report invocations as error for every .fail call

### DIFF
--- a/src/report.js
+++ b/src/report.js
@@ -138,11 +138,10 @@ class Report {
 
     // Add error to report if necessary
     if (err) {
-      const reportError = typeof err === 'string' ? new Error(err) : err;
-      // const reportError =
-      //   err instanceof Error
-      //     ? err
-      //     : new Error(typeof err === 'string' ? err : JSON.stringify(err));
+      const reportError =
+        err instanceof Error
+          ? err
+          : new Error(typeof err === 'string' ? err : JSON.stringify(err));
       const {
         name,
         message,

--- a/src/report.js
+++ b/src/report.js
@@ -139,6 +139,10 @@ class Report {
     // Add error to report if necessary
     if (err) {
       const reportError = typeof err === 'string' ? new Error(err) : err;
+      // const reportError =
+      //   err instanceof Error
+      //     ? err
+      //     : new Error(typeof err === 'string' ? err : JSON.stringify(err));
       const {
         name,
         message,


### PR DESCRIPTION
Currently if an invocation passes anything other than a string or an Error to .fail or the callback, the invocation will report as an error to AWS but not to IOpipe.  fix #268