### PR TITLE
build(circleci): CircleCI yaml ordering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,32 @@ defaults: &defaults
 
 version: 2
 
+workflows:
+  version: 2
+  all:
+    jobs:
+      - install
+      - test:
+          requires:
+            - install
+      - acceptanceTests:
+          requires:
+            - install
+            - test
+          filters:
+            branches:
+              only: master
+      - release:
+          requires:
+            - install
+            - test
+            - acceptanceTests
+          filters:
+            branches:
+              only: master
+            tags:
+              only: /^v.*/
+
 jobs:
   install:
     <<: *defaults
@@ -53,29 +79,3 @@ jobs:
       - run: yarn run build
       - run: cp .npmrc-ci .npmrc
       - run: yarn run release
-
-workflows:
-  version: 2
-  all:
-    jobs:
-      - install
-      - test:
-          requires:
-            - install
-      - acceptanceTests:
-          requires:
-            - install
-            - test
-          filters:
-            branches:
-              only: master
-      - release:
-          requires:
-            - install
-            - test
-            - acceptanceTests
-          filters:
-            branches:
-              only: master
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
Update ordering so workflows are above jobs, will allow Circle to run and avoid it complaining about this in the future.