### PR TITLE
fix(http): Abort request if the timeout is reached. (Fixes #312)

### DIFF
--- a/src/sendReport.js
+++ b/src/sendReport.js
@@ -35,10 +35,12 @@ function sendReport(requestBody, config, ipAddress) {
       )
       .on('error', err => {
         reject(err);
-      })
-      .setTimeout(config.networkTimeout, () => {
+      });
+    if (Number.isInteger(config.networkTimeout) && config.networkTimeout > 0) {
+      req.setTimeout(config.networkTimeout, () => {
         req.abort();
       });
+    }
 
     req.write(JSON.stringify(requestBody));
     req.end();

--- a/src/sendReport.js
+++ b/src/sendReport.js
@@ -19,8 +19,7 @@ function sendReport(requestBody, config, ipAddress) {
             authorization: `Bearer ${config.clientId}`,
             'content-type': 'application/json'
           },
-          agent: httpsAgent,
-          timeout: config.networkTimeout
+          agent: httpsAgent
         },
         res => {
           let apiResponse = '';
@@ -37,6 +36,10 @@ function sendReport(requestBody, config, ipAddress) {
       .on('error', err => {
         reject(err);
       });
+
+    req.setTimeout(config.networkTimeout, () => {
+      req.abort();
+    });
 
     req.write(JSON.stringify(requestBody));
     req.end();

--- a/src/sendReport.js
+++ b/src/sendReport.js
@@ -35,11 +35,10 @@ function sendReport(requestBody, config, ipAddress) {
       )
       .on('error', err => {
         reject(err);
+      })
+      .setTimeout(config.networkTimeout, () => {
+        req.abort();
       });
-
-    req.setTimeout(config.networkTimeout, () => {
-      req.abort();
-    });
 
     req.write(JSON.stringify(requestBody));
     req.end();


### PR DESCRIPTION
Setting the request timeout does not actually set some timeout for the socket (connect or read timeout), it actually just sets a callback to be made after the request is made if it has not finished by the time has passed. Since there was no actual event handler nothing was ever called, so now when the timeout is reach the connection is `abort()`ed which also according to the docs destroys the connection as well.

Note that I use `setTimeout(...)` because it seemed that `.on('timeout', ...)` was not working or doing anything at all.