### PR TITLE
Allow a collector to be specified via env vars. (Fixes #262, Fixes #261)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,10 @@ exports.handler = iopipe((event, context, callback) => {
 
 Conditionally enable/disable the agent. The environment variable `$IOPIPE_ENABLED` will also be checked.
 
+#### `url` (string: optional)
+
+Sets an alternative URL to use for the IOpipe collector. The environment variable `$IOPIPE_COLLECTOR_URL` will be used if present.
+
 ## RC File Configuration
 Not recommended for webpack/bundlers due to dynamic require.
 

--- a/src/config/environment.js
+++ b/src/config/environment.js
@@ -1,5 +1,7 @@
 import CosmiConfig from './cosmi';
 
+const url = require('url');
+
 export default class EnvironmentConfig extends CosmiConfig {
   /**
    * Environment variable configuration
@@ -30,6 +32,12 @@ export default class EnvironmentConfig extends CosmiConfig {
       : super.enabled;
   }
 
+  get host() {
+    return process.env.IOPIPE_COLLECTOR_URL
+      ? url.parse(process.env.IOPIPE_COLLECTOR_URL).hostname
+      : super.host;
+  }
+
   get installMethod() {
     return process.env.IOPIPE_INSTALL_METHOD || super.installMethod;
   }
@@ -38,6 +46,12 @@ export default class EnvironmentConfig extends CosmiConfig {
     return Number.isInteger(parseInt(process.env.IOPIPE_NETWORK_TIMEOUT, 10))
       ? parseInt(process.env.IOPIPE_NETWORK_TIMEOUT, 10)
       : super.networkTimeout;
+  }
+
+  get path() {
+    return process.env.IOPIPE_COLLECTOR_URL
+      ? url.parse(process.env.IOPIPE_COLLECTOR_URL).pathname
+      : super.path;
   }
 
   get timeoutWindow() {


### PR DESCRIPTION
This allows an alternative collector to be specified via the `IOPIPE_COLLECTOR_URL` environment variable. Additionally this documents the `url` parameter along with the environment variable.