### PR TITLE
fix(schema): restructures dbtrace

### DIFF
--- a/src/report.test.js
+++ b/src/report.test.js
@@ -103,11 +103,10 @@ describe('Report creation', () => {
         'dbTraceEntries.0.dbType',
         'dbTraceEntries.0.request.hash',
         'dbTraceEntries.0.request.command',
-        'dbTraceEntries.0.request.args.0.arg',
+        'dbTraceEntries.0.request.key',
         'dbTraceEntries.0.request.hostname',
         'dbTraceEntries.0.request.port',
         'dbTraceEntries.0.request.connectionName',
-        'dbTraceEntries.0.response.total',
         'dbTraceEntries.0.type'
       ];
 

--- a/src/report.test.js
+++ b/src/report.test.js
@@ -101,7 +101,6 @@ describe('Report creation', () => {
         'dbTraceEntries.0.duration',
         'dbTraceEntries.0.timestamp',
         'dbTraceEntries.0.dbType',
-        'dbTraceEntries.0.request.hash',
         'dbTraceEntries.0.request.command',
         'dbTraceEntries.0.request.key',
         'dbTraceEntries.0.request.hostname',

--- a/src/schema.json
+++ b/src/schema.json
@@ -180,7 +180,6 @@
       "timestamp": "n",
       "dbType": "s",
       "request": {
-        "hash": "s",
         "command": "s",
         "key": "s",
         "hostname": "s",

--- a/src/schema.json
+++ b/src/schema.json
@@ -182,17 +182,10 @@
       "request": {
         "hash": "s",
         "command": "s",
-        "args": [
-          {
-            "arg": "s"
-          }
-        ],
+        "key": "s",
         "hostname": "s",
         "port": "s",
         "connectionName": "s"
-      },
-      "response": {
-        "total": "n"
       },
       "type": "s"
     }


### PR DESCRIPTION
Replaces args[arr] dbtrace property with a simple key string, and removes unused dbtrace response property.