### PR TITLE
fix: Fix this var for getRemainingTimeInMillis with NSolid layer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,7 @@ function setupTimeoutCapture(wrapperInstance) {
   const maxEndTime = 899900; /* Maximum execution: 100ms short of 15 minutes */
   const configEndTime = Math.max(
     0,
-    getRemainingTimeInMillis() - config.timeoutWindow
+    getRemainingTimeInMillis.call(context) - config.timeoutWindow
   );
 
   const endTime = Math.min(configEndTime, maxEndTime);


### PR DESCRIPTION
Seeking to get the IOpipe js layer working with the nsolid provider layer!

Signed-off-by: Erica Windisch <73207+ewindisch@users.noreply.github.com>