### PR TITLE
Updating wrapped callback to wait for longer-running promises.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -157,8 +157,8 @@ class IOpipeWrapperClass {
         this.callback
       );
       if (result && result.then && result.catch) {
-        return new Promise(() => this.callback(null, () => result))
-          .then(value => value)
+        return new Promise(() => result)
+          .then(value => this.callback(null, () => value))
           .catch(err => {
             this.sendReport(err, () => this.originalCallback(err));
             return err;

--- a/src/index.js
+++ b/src/index.js
@@ -156,13 +156,19 @@ class IOpipeWrapperClass {
         this.context,
         this.callback
       );
-      if (result && result.then && result.catch) {
-        return new Promise(() => result)
-          .then(value => this.callback(null, () => value))
-          .catch(err => {
-            this.sendReport(err, () => this.originalCallback(err));
-            return err;
-          });
+      if (
+        result &&
+        typeof result.then === 'function' &&
+        typeof result.catch === 'function'
+      ) {
+        return new Promise((resolve, reject) => {
+          return result
+            .then(value => this.callback(null, () => resolve(value)))
+            .catch(err => {
+              this.sendReport(err, () => this.originalCallback(err));
+              return reject(err);
+            });
+        });
       }
       return result;
     } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,7 @@ class IOpipeWrapperClass {
         typeof result.then === 'function' &&
         typeof result.catch === 'function'
       ) {
-        return new Promise((resolve, reject) => {
+        return new Promise(resolve => {
           return result
             .then(value => {
               this.context.succeed(value);
@@ -169,8 +169,7 @@ class IOpipeWrapperClass {
             })
             .catch(err => {
               this.context.fail(err);
-              this.sendReport(err, () => this.originalCallback(err));
-              return reject(err);
+              return this.callback(err);
             });
         });
       }

--- a/src/index.js
+++ b/src/index.js
@@ -163,8 +163,12 @@ class IOpipeWrapperClass {
       ) {
         return new Promise((resolve, reject) => {
           return result
-            .then(value => this.callback(null, () => resolve(value)))
+            .then(value => {
+              this.context.succeed(value);
+              return this.callback(null, () => resolve(value));
+            })
             .catch(err => {
+              this.context.fail(err);
               this.sendReport(err, () => this.originalCallback(err));
               return reject(err);
             });


### PR DESCRIPTION
Wrapped promise results could be sent too early; this lets them resolve before send. 