### PR TITLE
Separating succeed and callback for promises

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -165,6 +165,9 @@ class IOpipeWrapperClass {
           return result
             .then(value => {
               this.context.succeed(value);
+              return value;
+            })
+            .then(value => {
               return this.callback(null, () => resolve(value));
             })
             .catch(err => {


### PR DESCRIPTION
Separating context.succeed and callback calls into separate .thenables on the agent's promise-handling callback.  Checking if this reduces or eliminates the intermittent timing error on previous CircleCI builds.