### PR TITLE
fix(schema): add `bulkCommands` to dbTraceEntries

### DIFF
--- a/src/report.test.js
+++ b/src/report.test.js
@@ -103,6 +103,7 @@ describe('Report creation', () => {
         'dbTraceEntries.0.timestamp',
         'dbTraceEntries.0.dbType',
         'dbTraceEntries.0.request.command',
+        'dbTraceEntries.0.request.bulkCommands',
         'dbTraceEntries.0.request.key',
         'dbTraceEntries.0.request.hostname',
         'dbTraceEntries.0.request.port',

--- a/src/schema.json
+++ b/src/schema.json
@@ -182,6 +182,7 @@
       "dbType": "s",
       "request": {
         "command": "s",
+        "bulkCommands": "s",
         "key": "s",
         "hostname": "s",
         "port": "s",


### PR DESCRIPTION
This adds support for separating bulk commands from key logging, letting them be treated separately in the dashboard.
Closes #345